### PR TITLE
Fix admin view includes and adjust textdomain loading

### DIFF
--- a/vr-single-property.php
+++ b/vr-single-property.php
@@ -63,8 +63,6 @@ require_once $file;
 add_action(
 'plugins_loaded',
 static function () {
-load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
-
 if ( class_exists( '\\VRSP\\Plugin' ) ) {
 \VRSP\Plugin::get_instance();
 }


### PR DESCRIPTION
## Summary
- ensure admin menu pages load templates from the plugin's admin/views directory and log missing files gracefully
- rely on the Plugin class' init hook for textdomain loading to avoid early translation notices

## Testing
- php -l includes/Admin/class-menu.php
- php -l vr-single-property.php

------
https://chatgpt.com/codex/tasks/task_e_68da9a9e72d8832488fdc46e4eeac85d