### PR TITLE
Add rental admin listing and block improvements

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,15 +1,27 @@
 <?php
 if ( ! current_user_can( 'manage_options' ) ) {
-return;
+    return;
 }
+
+$rental_id = function_exists( 'vrsp_get_primary_rental_id' ) ? vrsp_get_primary_rental_id() : 0;
+$add_url   = admin_url( 'post-new.php?post_type=vrsp_rental' );
+$edit_url  = $rental_id ? get_edit_post_link( $rental_id, 'display' ) : '';
 ?>
 <div class="wrap vrsp-admin">
-<h1><?php esc_html_e( 'VR Single Property Dashboard', 'vr-single-property' ); ?></h1>
-<p><?php esc_html_e( 'Monitor bookings, revenue, and operational automations.', 'vr-single-property' ); ?></p>
+    <h1><?php esc_html_e( 'VR Single Property Dashboard', 'vr-single-property' ); ?></h1>
+    <p><?php esc_html_e( 'Monitor bookings, revenue, and operational automations.', 'vr-single-property' ); ?></p>
 
-<div class="vrsp-cards">
-<div class="vrsp-card">
-<h2><?php esc_html_e( 'Upcoming Arrivals', 'vr-single-property' ); ?></h2>
+    <div class="vrsp-dashboard-cta" style="margin:16px 0;">
+        <?php if ( $rental_id && $edit_url ) : ?>
+            <a class="button button-primary" href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Edit Rental', 'vr-single-property' ); ?></a>
+        <?php else : ?>
+            <a class="button button-primary" href="<?php echo esc_url( $add_url ); ?>"><?php esc_html_e( 'Add Rental', 'vr-single-property' ); ?></a>
+        <?php endif; ?>
+    </div>
+
+    <div class="vrsp-cards">
+        <div class="vrsp-card">
+            <h2><?php esc_html_e( 'Upcoming Arrivals', 'vr-single-property' ); ?></h2>
 <ul>
 <?php
 $upcoming = get_posts(

--- a/includes/Admin/class-menu.php
+++ b/includes/Admin/class-menu.php
@@ -38,17 +38,25 @@ add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 }
 
 public function register_menu(): void {
-add_menu_page(
-__( 'VR Rental', 'vr-single-property' ),
-__( 'VR Rental', 'vr-single-property' ),
-'manage_options',
-'vrsp-dashboard',
-[ $this, 'render_dashboard' ],
-'dashicons-admin-multisite',
-30
-);
+        add_menu_page(
+            __( 'VR Rental', 'vr-single-property' ),
+            __( 'VR Rental', 'vr-single-property' ),
+            'manage_options',
+            'vrsp-dashboard',
+            [ $this, 'render_dashboard' ],
+            'dashicons-admin-multisite',
+            30
+        );
 
-add_submenu_page( 'vrsp-dashboard', __( 'Settings', 'vr-single-property' ), __( 'Settings', 'vr-single-property' ), 'manage_options', 'vrsp-settings', [ $this, 'render_settings_page' ] );
+        add_submenu_page(
+            'vrsp-dashboard',
+            __( 'Rentals', 'vr-single-property' ),
+            __( 'Rentals', 'vr-single-property' ),
+            'manage_options',
+            'edit.php?post_type=vrsp_rental'
+        );
+
+        add_submenu_page( 'vrsp-dashboard', __( 'Settings', 'vr-single-property' ), __( 'Settings', 'vr-single-property' ), 'manage_options', 'vrsp-settings', [ $this, 'render_settings_page' ] );
 add_submenu_page( 'vrsp-dashboard', __( 'Bookings', 'vr-single-property' ), __( 'Bookings', 'vr-single-property' ), 'manage_options', 'vrsp-bookings', [ $this, 'render_bookings_page' ] );
 add_submenu_page( 'vrsp-dashboard', __( 'Logs', 'vr-single-property' ), __( 'Logs', 'vr-single-property' ), 'manage_options', 'vrsp-logs', [ $this, 'render_logs_page' ] );
 }

--- a/includes/Blocks/class-listing-block.php
+++ b/includes/Blocks/class-listing-block.php
@@ -7,6 +7,7 @@ use VRSP\Settings;
 use VRSP\Utilities\Logger;
 use VRSP\Utilities\PricingEngine;
 use VRSP\Utilities\TemplateLoader;
+use WP_Post;
 
 /**
  * Listing block renderer and shortcode.
@@ -19,33 +20,74 @@ private $rules;
 private $logger;
 private $templates;
 
-public function __construct( Settings $settings, PricingEngine $pricing, StripeGateway $stripe, BusinessRules $rules, Logger $logger, TemplateLoader $templates ) {
-$this->settings  = $settings;
-$this->pricing   = $pricing;
-$this->stripe    = $stripe;
-$this->rules     = $rules;
-$this->logger    = $logger;
-$this->templates = $templates;
+    public function __construct( Settings $settings, PricingEngine $pricing, StripeGateway $stripe, BusinessRules $rules, Logger $logger, TemplateLoader $templates ) {
+        $this->settings  = $settings;
+        $this->pricing   = $pricing;
+        $this->stripe    = $stripe;
+        $this->rules     = $rules;
+        $this->logger    = $logger;
+        $this->templates = $templates;
 
-add_action( 'init', [ $this, 'register_block' ] );
-add_shortcode( 'vrsp_listing', [ $this, 'shortcode' ] );
-}
+        add_action( 'init', [ $this, 'register_block' ] );
+        add_shortcode( 'vrsp_listing', [ $this, 'shortcode' ] );
+    }
 
-public function register_block(): void {
-register_block_type_from_metadata(
-VRSP_PLUGIN_DIR . 'blocks/listing',
-[
-'render_callback' => [ $this, 'render_block' ],
-]
-);
-}
+    public function register_block(): void {
+        $block_dir = VRSP_PLUGIN_DIR . 'blocks/listing';
 
-public function render_block( array $attributes, string $content ): string {
-wp_enqueue_style( 'vrsp-public', VRSP_PLUGIN_URL . 'public/css/public.css', [], VRSP_VERSION );
-wp_enqueue_script( 'vrsp-listing', VRSP_PLUGIN_URL . 'public/js/listing.js', [], VRSP_VERSION, true );
-wp_localize_script(
-'vrsp-listing',
-'vrspListing',
+        if ( file_exists( $block_dir . '/block.json' ) && function_exists( 'register_block_type_from_metadata' ) ) {
+            register_block_type_from_metadata(
+                $block_dir,
+                [
+                    'render_callback' => [ $this, 'render_block' ],
+                ]
+            );
+            return;
+        }
+
+        $handle = 'vrsp-listing-block-editor';
+
+        wp_register_script(
+            $handle,
+            VRSP_PLUGIN_URL . 'blocks/listing/editor.js',
+            [ 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n' ],
+            VRSP_VERSION,
+            true
+        );
+
+        $editor_style = VRSP_PLUGIN_DIR . 'blocks/listing/editor.css';
+
+        if ( file_exists( $editor_style ) ) {
+            wp_register_style( 'vrsp-listing-block-editor', VRSP_PLUGIN_URL . 'blocks/listing/editor.css', [], VRSP_VERSION );
+        }
+
+        $args = [
+            'editor_script'   => $handle,
+            'render_callback' => [ $this, 'render_block' ],
+        ];
+
+        if ( file_exists( $editor_style ) ) {
+            $args['editor_style'] = 'vrsp-listing-block-editor';
+        }
+
+        register_block_type( 'vrsp/listing', $args );
+    }
+
+    public function render_block( array $attributes, string $content ): string {
+        $rental = $this->get_primary_rental();
+
+        if ( ! $rental ) {
+            return sprintf(
+                '<div class="vrsp-notice vrsp-notice--warning">%s</div>',
+                \esc_html__( 'No rental has been published yet. Please add one under VR Rental → Rentals.', 'vr-single-property' )
+            );
+        }
+
+        wp_enqueue_style( 'vrsp-public', VRSP_PLUGIN_URL . 'public/css/public.css', [], VRSP_VERSION );
+        wp_enqueue_script( 'vrsp-listing', VRSP_PLUGIN_URL . 'public/js/listing.js', [], VRSP_VERSION, true );
+        wp_localize_script(
+            'vrsp-listing',
+            'vrspListing',
 [
 'api'      => esc_url_raw( rest_url( 'vr/v1' ) ),
 'currency' => $this->settings->get( 'currency', 'USD' ),
@@ -54,13 +96,30 @@ wp_localize_script(
 ]
 );
 
-return $this->templates->render( 'listing/listing.php', [
-'content' => $content,
-'attrs'   => $attributes,
-] );
-}
+        return $this->templates->render( 'listing/listing.php', [
+            'content' => $content,
+            'attrs'   => $attributes,
+            'rental'  => $rental,
+        ] );
+    }
 
-public function shortcode( $atts ): string {
-return $this->render_block( [], '' );
-}
+    public function shortcode( $atts ): string {
+        return $this->render_block( [], '' );
+    }
+
+    private function get_primary_rental(): ?WP_Post {
+        if ( ! function_exists( 'vrsp_get_primary_rental_id' ) ) {
+            return null;
+        }
+
+        $rental_id = vrsp_get_primary_rental_id();
+
+        if ( ! $rental_id ) {
+            return null;
+        }
+
+        $rental = get_post( $rental_id );
+
+        return $rental instanceof WP_Post ? $rental : null;
+    }
 }

--- a/includes/PostTypes/class-rental-post-type.php
+++ b/includes/PostTypes/class-rental-post-type.php
@@ -13,20 +13,38 @@ public static function register(): void {
 add_action( 'init', [ static::class, 'register_post_type' ] );
 }
 
-public static function register_post_type(): void {
-register_post_type(
-self::get_key(),
-[
-'labels'       => [
-'name'          => __( 'Rental', 'vr-single-property' ),
-'singular_name' => __( 'Rental', 'vr-single-property' ),
-],
-'public'       => true,
-'show_in_menu' => false,
-'show_in_rest' => true,
-'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ],
-'has_archive'  => false,
-]
-);
-}
+    public static function register_post_type(): void {
+        register_post_type(
+            self::get_key(),
+            [
+                'labels'       => [
+                    'name'               => __( 'Rentals', 'vr-single-property' ),
+                    'singular_name'      => __( 'Rental', 'vr-single-property' ),
+                    'add_new'            => __( 'Add Rental', 'vr-single-property' ),
+                    'add_new_item'       => __( 'Add New Rental', 'vr-single-property' ),
+                    'edit_item'          => __( 'Edit Rental', 'vr-single-property' ),
+                    'new_item'           => __( 'New Rental', 'vr-single-property' ),
+                    'view_item'          => __( 'View Rental', 'vr-single-property' ),
+                    'search_items'       => __( 'Search Rentals', 'vr-single-property' ),
+                    'not_found'          => __( 'No rentals found', 'vr-single-property' ),
+                    'not_found_in_trash' => __( 'No rentals found in Trash', 'vr-single-property' ),
+                    'menu_name'          => __( 'Rentals', 'vr-single-property' ),
+                ],
+                'public'              => true,
+                'show_ui'             => true,
+                'show_in_menu'        => 'vrsp-dashboard',
+                'show_in_admin_bar'   => true,
+                'show_in_rest'        => true,
+                'supports'            => [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ],
+                'has_archive'         => false,
+                'rewrite'             => [
+                    'slug'       => 'rental',
+                    'with_front' => false,
+                ],
+                'menu_position'       => null,
+                'publicly_queryable'  => true,
+                'exclude_from_search' => false,
+            ]
+        );
+    }
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -57,18 +57,20 @@ return self::$instance;
 /**
  * Activation hook.
  */
-public static function activate(): void {
-self::get_instance();
-BasePostType::flush_rewrite();
-CronManager::activate();
-}
+    public static function activate(): void {
+        self::get_instance();
+        RentalPostType::register_post_type();
+        BasePostType::flush_rewrite();
+        CronManager::activate();
+    }
 
 /**
  * Deactivation hook.
  */
-public static function deactivate(): void {
-CronManager::deactivate();
-}
+    public static function deactivate(): void {
+        CronManager::deactivate();
+        BasePostType::flush_rewrite();
+    }
 
 /**
  * Constructor.

--- a/includes/helpers-rental.php
+++ b/includes/helpers-rental.php
@@ -1,0 +1,27 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'vrsp_get_primary_rental_id' ) ) {
+    /**
+     * Retrieve the primary rental ID for single-property workflows.
+     */
+    function vrsp_get_primary_rental_id(): int {
+        $query = new WP_Query(
+            [
+                'post_type'      => 'vrsp_rental',
+                'post_status'    => 'publish',
+                'posts_per_page' => 1,
+                'orderby'        => [
+                    'menu_order' => 'ASC',
+                    'date'       => 'ASC',
+                ],
+                'no_found_rows'  => true,
+                'fields'         => 'ids',
+            ]
+        );
+
+        return $query->have_posts() ? (int) $query->posts[0] : 0;
+    }
+}

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -1,37 +1,35 @@
 <?php
-$rental = get_posts(
-[
-'post_type'      => 'vrsp_rental',
-'posts_per_page' => 1,
-]
-);
-$rental = $rental ? $rental[0] : null;
-$gallery   = $rental ? get_attached_media( 'image', $rental->ID ) : [];
+/** @var WP_Post $rental */
+if ( ! isset( $rental ) || ! $rental instanceof WP_Post ) {
+    return;
+}
+
+$gallery   = get_attached_media( 'image', $rental->ID );
 $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
 ?>
 <div class="vrsp-listing">
-<div class="vrsp-hero">
-<?php if ( $gallery ) :
-$images = array_slice( $gallery, 0, 4 );
-foreach ( $images as $image ) :
+    <div class="vrsp-hero">
+        <?php if ( $gallery ) :
+            $images = array_slice( $gallery, 0, 4 );
+            foreach ( $images as $image ) :
 ?>
 <img src="<?php echo esc_url( wp_get_attachment_image_url( $image->ID, 'large' ) ); ?>" alt="<?php echo esc_attr( get_post_meta( $image->ID, '_wp_attachment_image_alt', true ) ); ?>" />
 <?php endforeach; else : ?>
 <img src="<?php echo esc_url( VRSP_PLUGIN_URL . 'assets/placeholder.jpg' ); ?>" alt="" />
 <?php endif; ?>
-</div>
+    </div>
 
-<div class="vrsp-content">
-<div class="vrsp-grid two">
-<div class="vrsp-card">
-<h2><?php echo esc_html( get_the_title( $rental ) ); ?></h2>
-<div class="vrsp-description"><?php echo wp_kses_post( apply_filters( 'the_content', $rental ? $rental->post_content : '' ) ); ?></div>
-</div>
-<div class="vrsp-card vrsp-calendar">
-<h3><?php esc_html_e( 'Availability', 'vr-single-property' ); ?></h3>
-<div class="vrsp-availability"></div>
-<p><?php esc_html_e( 'Bookings auto-sync across Airbnb, VRBO, and Booking.com via iCal.', 'vr-single-property' ); ?></p>
+    <div class="vrsp-content">
+        <div class="vrsp-grid two">
+            <div class="vrsp-card">
+                <h2><?php echo esc_html( get_the_title( $rental ) ); ?></h2>
+                <div class="vrsp-description"><?php echo wp_kses_post( apply_filters( 'the_content', $rental->post_content ) ); ?></div>
+            </div>
+            <div class="vrsp-card vrsp-calendar">
+                <h3><?php esc_html_e( 'Availability', 'vr-single-property' ); ?></h3>
+                <div class="vrsp-availability"></div>
+                <p><?php esc_html_e( 'Bookings auto-sync across Airbnb, VRBO, and Booking.com via iCal.', 'vr-single-property' ); ?></p>
 </div>
 </div>
 

--- a/vr-single-property.php
+++ b/vr-single-property.php
@@ -30,6 +30,8 @@ define( 'VRSP_PLUGIN_FILE', __FILE__ );
 define( 'VRSP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VRSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
+require_once VRSP_PLUGIN_DIR . 'includes/helpers-rental.php';
+
 spl_autoload_register(
 static function ( $class ) {
 if ( 0 !== strpos( $class, 'VRSP\\' ) ) {


### PR DESCRIPTION
## Summary
- expose the vrsp_rental custom post type under the VR Rental menu with richer labels and rewrite support
- load a rental helper for selecting the primary rental and reuse it in the listing block, shortcode, and template
- surface Add/Edit Rental dashboard calls-to-action and ensure the listing block registers with a block.json or script fallback

## Testing
- php -l includes/helpers-rental.php
- php -l vr-single-property.php
- php -l includes/PostTypes/class-rental-post-type.php
- php -l includes/class-plugin.php
- php -l includes/Admin/class-menu.php
- php -l admin/views/dashboard.php
- php -l templates/listing/listing.php
- php -l includes/Blocks/class-listing-block.php

------
https://chatgpt.com/codex/tasks/task_e_68daa267e1cc832484382b6f02b0d744