### PR TITLE
Prevent recursive listing rendering and adjust activation

### DIFF
--- a/includes/PostTypes/class-rental-post-type.php
+++ b/includes/PostTypes/class-rental-post-type.php
@@ -17,19 +17,7 @@ add_action( 'init', [ static::class, 'register_post_type' ] );
         register_post_type(
             self::get_key(),
             [
-                'labels'       => [
-                    'name'               => __( 'Rentals', 'vr-single-property' ),
-                    'singular_name'      => __( 'Rental', 'vr-single-property' ),
-                    'add_new'            => __( 'Add Rental', 'vr-single-property' ),
-                    'add_new_item'       => __( 'Add New Rental', 'vr-single-property' ),
-                    'edit_item'          => __( 'Edit Rental', 'vr-single-property' ),
-                    'new_item'           => __( 'New Rental', 'vr-single-property' ),
-                    'view_item'          => __( 'View Rental', 'vr-single-property' ),
-                    'search_items'       => __( 'Search Rentals', 'vr-single-property' ),
-                    'not_found'          => __( 'No rentals found', 'vr-single-property' ),
-                    'not_found_in_trash' => __( 'No rentals found in Trash', 'vr-single-property' ),
-                    'menu_name'          => __( 'Rentals', 'vr-single-property' ),
-                ],
+                'labels'       => self::get_labels(),
                 'public'              => true,
                 'show_ui'             => true,
                 'show_in_menu'        => 'vrsp-dashboard',
@@ -46,5 +34,23 @@ add_action( 'init', [ static::class, 'register_post_type' ] );
                 'exclude_from_search' => false,
             ]
         );
+    }
+
+    private static function get_labels(): array {
+        $translate = did_action( 'init' );
+
+        return [
+            'name'               => $translate ? __( 'Rentals', 'vr-single-property' ) : 'Rentals',
+            'singular_name'      => $translate ? __( 'Rental', 'vr-single-property' ) : 'Rental',
+            'add_new'            => $translate ? __( 'Add Rental', 'vr-single-property' ) : 'Add Rental',
+            'add_new_item'       => $translate ? __( 'Add New Rental', 'vr-single-property' ) : 'Add New Rental',
+            'edit_item'          => $translate ? __( 'Edit Rental', 'vr-single-property' ) : 'Edit Rental',
+            'new_item'           => $translate ? __( 'New Rental', 'vr-single-property' ) : 'New Rental',
+            'view_item'          => $translate ? __( 'View Rental', 'vr-single-property' ) : 'View Rental',
+            'search_items'       => $translate ? __( 'Search Rentals', 'vr-single-property' ) : 'Search Rentals',
+            'not_found'          => $translate ? __( 'No rentals found', 'vr-single-property' ) : 'No rentals found',
+            'not_found_in_trash' => $translate ? __( 'No rentals found in Trash', 'vr-single-property' ) : 'No rentals found in Trash',
+            'menu_name'          => $translate ? __( 'Rentals', 'vr-single-property' ) : 'Rentals',
+        ];
     }
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -59,6 +59,9 @@ return self::$instance;
  */
     public static function activate(): void {
         self::get_instance();
+        if ( function_exists( 'load_plugin_textdomain' ) ) {
+            load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
+        }
         RentalPostType::register_post_type();
         BasePostType::flush_rewrite();
         CronManager::activate();

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -7,6 +7,15 @@ if ( ! isset( $rental ) || ! $rental instanceof WP_Post ) {
 $gallery   = get_attached_media( 'image', $rental->ID );
 $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
+$content   = $rental->post_content;
+
+if ( class_exists( '\\VRSP\\Blocks\\ListingBlock' ) && \VRSP\Blocks\ListingBlock::is_rendering() ) {
+    $content = wpautop( $content );
+} else {
+    $content = apply_filters( 'the_content', $content );
+}
+
+$content = wp_kses_post( $content );
 ?>
 <div class="vrsp-listing">
     <div class="vrsp-hero">
@@ -24,7 +33,7 @@ $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 20
         <div class="vrsp-grid two">
             <div class="vrsp-card">
                 <h2><?php echo esc_html( get_the_title( $rental ) ); ?></h2>
-                <div class="vrsp-description"><?php echo wp_kses_post( apply_filters( 'the_content', $rental->post_content ) ); ?></div>
+                <div class="vrsp-description"><?php echo $content; ?></div>
             </div>
             <div class="vrsp-card vrsp-calendar">
                 <h3><?php esc_html_e( 'Availability', 'vr-single-property' ); ?></h3>


### PR DESCRIPTION
## Summary
- add a static re-entrancy guard for the listing block renderer and expose its state
- ensure the listing template avoids triggering nested renders while still formatting content safely
- fall back to untranslated labels before init and preload the textdomain during activation

## Testing
- php -l includes/Blocks/class-listing-block.php
- php -l templates/listing/listing.php
- php -l includes/PostTypes/class-rental-post-type.php
- php -l includes/class-plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68dabd2622f88324bcd85bffeceb9100