### PR TITLE
Prevent recursive listing rendering loops and defer translations

### DIFF
--- a/includes/PostTypes/class-rental-post-type.php
+++ b/includes/PostTypes/class-rental-post-type.php
@@ -1,35 +1,26 @@
 <?php
 namespace VRSP\PostTypes;
 
+use function __;
+use function did_action;
+
 /**
  * Rental post type.
  */
 class RentalPostType extends BasePostType {
-public static function get_key(): string {
-return 'vrsp_rental';
-}
+    public static function get_key(): string {
+        return 'vrsp_rental';
+    }
 
-public static function register(): void {
-add_action( 'init', [ static::class, 'register_post_type' ] );
-}
+    public static function register(): void {
+        add_action( 'init', [ static::class, 'register_post_type' ] );
+    }
 
     public static function register_post_type(): void {
         register_post_type(
             self::get_key(),
             [
-                'labels'       => [
-                    'name'               => __( 'Rentals', 'vr-single-property' ),
-                    'singular_name'      => __( 'Rental', 'vr-single-property' ),
-                    'add_new'            => __( 'Add Rental', 'vr-single-property' ),
-                    'add_new_item'       => __( 'Add New Rental', 'vr-single-property' ),
-                    'edit_item'          => __( 'Edit Rental', 'vr-single-property' ),
-                    'new_item'           => __( 'New Rental', 'vr-single-property' ),
-                    'view_item'          => __( 'View Rental', 'vr-single-property' ),
-                    'search_items'       => __( 'Search Rentals', 'vr-single-property' ),
-                    'not_found'          => __( 'No rentals found', 'vr-single-property' ),
-                    'not_found_in_trash' => __( 'No rentals found in Trash', 'vr-single-property' ),
-                    'menu_name'          => __( 'Rentals', 'vr-single-property' ),
-                ],
+                'labels'              => self::get_labels(),
                 'public'              => true,
                 'show_ui'             => true,
                 'show_in_menu'        => 'vrsp-dashboard',
@@ -46,5 +37,23 @@ add_action( 'init', [ static::class, 'register_post_type' ] );
                 'exclude_from_search' => false,
             ]
         );
+    }
+
+    private static function get_labels(): array {
+        $translate = did_action( 'init' );
+
+        return [
+            'name'               => $translate ? __( 'Rentals', 'vr-single-property' ) : 'Rentals',
+            'singular_name'      => $translate ? __( 'Rental', 'vr-single-property' ) : 'Rental',
+            'add_new'            => $translate ? __( 'Add Rental', 'vr-single-property' ) : 'Add Rental',
+            'add_new_item'       => $translate ? __( 'Add New Rental', 'vr-single-property' ) : 'Add New Rental',
+            'edit_item'          => $translate ? __( 'Edit Rental', 'vr-single-property' ) : 'Edit Rental',
+            'new_item'           => $translate ? __( 'New Rental', 'vr-single-property' ) : 'New Rental',
+            'view_item'          => $translate ? __( 'View Rental', 'vr-single-property' ) : 'View Rental',
+            'search_items'       => $translate ? __( 'Search Rentals', 'vr-single-property' ) : 'Search Rentals',
+            'not_found'          => $translate ? __( 'No rentals found', 'vr-single-property' ) : 'No rentals found',
+            'not_found_in_trash' => $translate ? __( 'No rentals found in Trash', 'vr-single-property' ) : 'No rentals found in Trash',
+            'menu_name'          => $translate ? __( 'Rentals', 'vr-single-property' ) : 'Rentals',
+        ];
     }
 }

--- a/includes/Utilities/class-cron-manager.php
+++ b/includes/Utilities/class-cron-manager.php
@@ -1,6 +1,9 @@
 <?php
 namespace VRSP\Utilities;
 
+use function __;
+use function did_action;
+
 use DateTimeImmutable;
 use VRSP\Integrations\CheckinApp;
 use VRSP\Integrations\IcalSync;
@@ -63,10 +66,16 @@ wp_clear_scheduled_hook( 'vrsp_housekeeping_notify' );
 }
 
 public function register_schedules( array $schedules ): array {
-$schedules['vrsp_quarter_hour'] = [
-'interval' => 15 * MINUTE_IN_SECONDS,
-'display'  => __( 'Every 15 Minutes', 'vr-single-property' ),
-];
+        $display = 'Every 15 Minutes';
+
+        if ( did_action( 'init' ) ) {
+            $display = __( 'Every 15 Minutes', 'vr-single-property' );
+        }
+
+        $schedules['vrsp_quarter_hour'] = [
+            'interval' => 15 * MINUTE_IN_SECONDS,
+            'display'  => $display,
+        ];
 
 return $schedules;
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -59,6 +59,9 @@ return self::$instance;
  */
     public static function activate(): void {
         self::get_instance();
+        if ( function_exists( 'load_plugin_textdomain' ) ) {
+            load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
+        }
         RentalPostType::register_post_type();
         BasePostType::flush_rewrite();
         CronManager::activate();
@@ -86,6 +89,7 @@ LogPostType::register();
 $this->boot_modules();
 
 add_action( 'init', [ $this, 'load_textdomain' ] );
+add_action( 'init', [ $this->settings, 'refresh' ], 11 );
 }
 
 /**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,6 +1,9 @@
 <?php
 namespace VRSP;
 
+use function __;
+use function did_action;
+
 /**
  * Settings repository.
  */
@@ -22,7 +25,14 @@ $this->settings = wp_parse_args( get_option( self::OPTION_KEY, [] ), $this->get_
  * Default settings.
  */
 public function get_defaults(): array {
-return [
+        $translate   = did_action( 'init' );
+        $house_rules = 'No smoking. No pets. Quiet hours after 10 PM.';
+
+        if ( $translate && function_exists( '__' ) ) {
+            $house_rules = __( 'No smoking. No pets. Quiet hours after 10 PM.', 'vr-single-property' );
+        }
+
+        return [
 'currency'                => 'USD',
 'base_rate'               => 200.0,
 'tax_rate'                => 0.12,
@@ -53,12 +63,12 @@ return [
 'uplift_cap'              => 0.15,
 'coupons'                 => [],
 'business_rules'          => [
-'checkin_time'       => '16:00',
-'checkout_time'      => '11:00',
-'deposit_threshold'  => 7,
-'deposit_percent'    => 0.5,
-'cancellation_days'  => 7,
-'house_rules'        => __( 'No smoking. No pets. Quiet hours after 10 PM.', 'vr-single-property' ),
+    'checkin_time'       => '16:00',
+    'checkout_time'      => '11:00',
+    'deposit_threshold'  => 7,
+    'deposit_percent'    => 0.5,
+    'cancellation_days'  => 7,
+    'house_rules'        => $house_rules,
 ],
 'email_templates'         => [],
 ];

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -7,6 +7,34 @@ if ( ! isset( $rental ) || ! $rental instanceof WP_Post ) {
 $gallery   = get_attached_media( 'image', $rental->ID );
 $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
+$content   = $rental->post_content;
+
+$patterns = [
+    '/\[vrsp_listing(?:\s+[^\]]*)?\](?:.*?\[\/vrsp_listing\])?/is',
+    '/<!--\s+wp:vrsp\/listing.*?-->.*?<!--\s+\/wp:vrsp\/listing\s+-->/is',
+    '/<!--\s+wp:vrsp\/listing\s+\/?-->/i',
+];
+
+foreach ( $patterns as $pattern ) {
+    $maybe = preg_replace( $pattern, '', $content );
+
+    if ( null !== $maybe ) {
+        $content = $maybe;
+    }
+}
+
+$content = trim( $content );
+
+$listing_block_class = 'VRSP\\Blocks\\ListingBlock';
+$guard_active        = class_exists( $listing_block_class ) && $listing_block_class::is_rendering();
+
+if ( $guard_active ) {
+    $content = wpautop( $content );
+} else {
+    $content = apply_filters( 'the_content', $content );
+}
+
+$content = wp_kses_post( $content );
 ?>
 <div class="vrsp-listing">
     <div class="vrsp-hero">
@@ -24,7 +52,7 @@ $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 20
         <div class="vrsp-grid two">
             <div class="vrsp-card">
                 <h2><?php echo esc_html( get_the_title( $rental ) ); ?></h2>
-                <div class="vrsp-description"><?php echo wp_kses_post( apply_filters( 'the_content', $rental->post_content ) ); ?></div>
+                <div class="vrsp-description"><?php echo $content; ?></div>
             </div>
             <div class="vrsp-card vrsp-calendar">
                 <h3><?php esc_html_e( 'Availability', 'vr-single-property' ); ?></h3>


### PR DESCRIPTION
## Summary
- strip vrsp listing shortcodes and blocks from rental content and fall back to guard-aware formatting to stop recursive renders
- only translate defaults and cron schedule labels after init and refresh settings once the text domain is loaded
- keep rental post type labels safe before init by using plain strings until translations are available

## Testing
- php -l includes/PostTypes/class-rental-post-type.php
- php -l includes/Utilities/class-cron-manager.php
- php -l includes/class-settings.php
- php -l includes/class-plugin.php
- php -l templates/listing/listing.php

------
https://chatgpt.com/codex/tasks/task_e_68dabd2622f88324bcd85bffeceb9100