### PR TITLE
Refactor booking flow with CRM approvals and mobile booking widget

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -26,3 +26,13 @@ text-transform: uppercase;
 .vrsp-admin .status-success { background: #d1fae5; color: #047857; }
 .vrsp-admin .status-warning { background: #fef3c7; color: #b45309; }
 .vrsp-admin .status-pending { background: #f3f4f6; color: #374151; }
+.vrsp-admin .status-info { background: #dbeafe; color: #1d4ed8; }
+
+.vrsp-admin .vrsp-bookings-table td,
+.vrsp-admin .vrsp-bookings-table th {
+    vertical-align: top;
+}
+
+.vrsp-admin .vrsp-bookings-table .vrsp-actions form {
+    margin: 0;
+}

--- a/admin/views/bookings.php
+++ b/admin/views/bookings.php
@@ -5,35 +5,64 @@ return;
 ?>
 <div class="wrap vrsp-admin">
 <h1><?php esc_html_e( 'Bookings', 'vr-single-property' ); ?></h1>
-<table class="widefat">
+<table class="widefat vrsp-bookings-table">
 <thead>
 <tr>
 <th><?php esc_html_e( 'Guest', 'vr-single-property' ); ?></th>
 <th><?php esc_html_e( 'Dates', 'vr-single-property' ); ?></th>
 <th><?php esc_html_e( 'Status', 'vr-single-property' ); ?></th>
-<th><?php esc_html_e( 'Total', 'vr-single-property' ); ?></th>
+<th><?php esc_html_e( 'Financials', 'vr-single-property' ); ?></th>
+<th><?php esc_html_e( 'Actions', 'vr-single-property' ); ?></th>
 </tr>
 </thead>
 <tbody>
 <?php if ( empty( $bookings ) ) : ?>
-<tr><td colspan="4"><?php esc_html_e( 'No bookings yet.', 'vr-single-property' ); ?></td></tr>
+<tr><td colspan="5"><?php esc_html_e( 'No bookings yet.', 'vr-single-property' ); ?></td></tr>
 <?php else :
 foreach ( $bookings as $booking ) :
 $quote = get_post_meta( $booking->ID, '_vrsp_quote', true );
+$admin_status = get_post_meta( $booking->ID, '_vrsp_admin_status', true );
+$status_labels = [];
+
+if ( get_post_meta( $booking->ID, '_vrsp_balance_paid', true ) ) {
+    $status_labels[] = '<span class="status status-success">' . esc_html__( 'Paid in Full', 'vr-single-property' ) . '</span>';
+} elseif ( get_post_meta( $booking->ID, '_vrsp_deposit_paid', true ) ) {
+    $status_labels[] = '<span class="status status-warning">' . esc_html__( 'Deposit Paid', 'vr-single-property' ) . '</span>';
+} else {
+    $status_labels[] = '<span class="status status-pending">' . esc_html__( 'Awaiting Payment', 'vr-single-property' ) . '</span>';
+}
+
+if ( 'pending_admin' === $admin_status ) {
+    $status_labels[] = '<span class="status status-info">' . esc_html__( 'Needs Approval', 'vr-single-property' ) . '</span>';
+} elseif ( 'approved' === $admin_status ) {
+    $status_labels[] = '<span class="status status-success">' . esc_html__( 'Approved', 'vr-single-property' ) . '</span>';
+}
 ?>
 <tr>
 <td><?php echo esc_html( get_the_title( $booking ) ); ?><br /><?php echo esc_html( get_post_meta( $booking->ID, '_vrsp_email', true ) ); ?></td>
 <td><?php echo esc_html( get_post_meta( $booking->ID, '_vrsp_arrival', true ) ); ?> &rarr; <?php echo esc_html( get_post_meta( $booking->ID, '_vrsp_departure', true ) ); ?></td>
+<td><?php echo wp_kses_post( implode( '<br />', $status_labels ) ); ?><br /><small><?php echo esc_html( ucfirst( get_post_status( $booking ) ) ); ?></small></td>
 <td>
-<?php if ( get_post_meta( $booking->ID, '_vrsp_balance_paid', true ) ) : ?>
-<span class="status status-success"><?php esc_html_e( 'Paid', 'vr-single-property' ); ?></span>
-<?php elseif ( get_post_meta( $booking->ID, '_vrsp_deposit_paid', true ) ) : ?>
-<span class="status status-warning"><?php esc_html_e( 'Deposit Paid', 'vr-single-property' ); ?></span>
-<?php else : ?>
-<span class="status status-pending"><?php esc_html_e( 'Pending', 'vr-single-property' ); ?></span>
-<?php endif; ?>
+    <strong><?php printf( '%s %s', esc_html( $quote['currency'] ?? 'USD' ), esc_html( number_format_i18n( $quote['total'] ?? 0, 2 ) ) ); ?></strong><br />
+    <?php if ( ! empty( $quote['deposit'] ) && $quote['deposit'] < ( $quote['total'] ?? 0 ) ) : ?>
+        <?php printf( esc_html__( 'Deposit: %1$s %2$s', 'vr-single-property' ), esc_html( $quote['currency'] ?? 'USD' ), esc_html( number_format_i18n( $quote['deposit'], 2 ) ) ); ?><br />
+        <?php printf( esc_html__( 'Balance: %1$s %2$s', 'vr-single-property' ), esc_html( $quote['currency'] ?? 'USD' ), esc_html( number_format_i18n( $quote['balance'] ?? 0, 2 ) ) ); ?>
+    <?php else : ?>
+        <?php esc_html_e( 'Full balance due now.', 'vr-single-property' ); ?>
+    <?php endif; ?>
 </td>
-<td><?php echo esc_html( $quote['currency'] ?? 'USD' ); ?> <?php echo esc_html( number_format_i18n( $quote['total'] ?? 0, 2 ) ); ?></td>
+<td class="vrsp-actions">
+    <?php if ( 'pending_admin' === $admin_status ) : ?>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <input type="hidden" name="action" value="vrsp_approve_booking" />
+            <input type="hidden" name="booking_id" value="<?php echo esc_attr( $booking->ID ); ?>" />
+            <?php wp_nonce_field( 'vrsp-approve-booking_' . $booking->ID ); ?>
+            <button type="submit" class="button button-primary"><?php esc_html_e( 'Approve &amp; Trigger Check-In', 'vr-single-property' ); ?></button>
+        </form>
+    <?php else : ?>
+        <span class="description"><?php esc_html_e( 'No actions', 'vr-single-property' ); ?></span>
+    <?php endif; ?>
+</td>
 </tr>
 <?php endforeach; endif; ?>
 </tbody>

--- a/includes/Utilities/class-rest-routes.php
+++ b/includes/Utilities/class-rest-routes.php
@@ -1,6 +1,7 @@
 <?php
 namespace VRSP\Utilities;
 
+use DateTimeImmutable;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -91,85 +92,213 @@ register_rest_route(
 }
 
 public function quote( WP_REST_Request $request ): WP_REST_Response {
-$body = $request->get_json_params();
-$arrival   = sanitize_text_field( $body['arrival'] ?? '' );
-$departure = sanitize_text_field( $body['departure'] ?? '' );
-$guests    = absint( $body['guests'] ?? 1 );
-$coupon    = sanitize_text_field( $body['coupon'] ?? '' );
+        $body = $request->get_json_params();
+        $arrival   = sanitize_text_field( $body['arrival'] ?? '' );
+        $departure = sanitize_text_field( $body['departure'] ?? '' );
+        $guests    = absint( $body['guests'] ?? 1 );
+        $coupon    = sanitize_text_field( $body['coupon'] ?? '' );
 
-if ( ! $arrival || ! $departure ) {
-return new WP_REST_Response( [ 'error' => __( 'Arrival and departure required.', 'vr-single-property' ) ], 400 );
-}
+        if ( ! $arrival || ! $departure ) {
+            return new WP_REST_Response( [ 'error' => __( 'Arrival and departure required.', 'vr-single-property' ) ], 400 );
+        }
 
-$this->pricing->track_view();
+        try {
+            $arrival_dt   = new DateTimeImmutable( $arrival );
+            $departure_dt = new DateTimeImmutable( $departure );
+        } catch ( \Exception $e ) {
+            return new WP_REST_Response( [ 'error' => __( 'Invalid dates supplied.', 'vr-single-property' ) ], 400 );
+        }
 
-$quote = $this->pricing->calculate_quote( $arrival, $departure, $guests, $coupon );
+        if ( $arrival_dt >= $departure_dt ) {
+            return new WP_REST_Response( [ 'error' => __( 'Departure must be after arrival.', 'vr-single-property' ) ], 400 );
+        }
 
-return new WP_REST_Response( $quote );
-}
+        if ( ! $this->ical->is_range_available( $arrival_dt, $departure_dt ) ) {
+            return new WP_REST_Response( [ 'error' => __( 'Those dates are no longer available.', 'vr-single-property' ) ], 409 );
+        }
+
+        $this->pricing->track_view();
+
+        $quote = $this->pricing->calculate_quote( $arrival_dt->format( 'Y-m-d' ), $departure_dt->format( 'Y-m-d' ), $guests, $coupon );
+
+        return new WP_REST_Response( $quote );
+    }
 
 public function create_booking( WP_REST_Request $request ) {
-$body = $request->get_json_params();
+        $body = $request->get_json_params();
 
-$required = [ 'arrival', 'departure', 'email', 'first_name', 'last_name' ];
-foreach ( $required as $field ) {
-if ( empty( $body[ $field ] ) ) {
-return new WP_Error( 'missing_field', sprintf( __( 'Field %s is required.', 'vr-single-property' ), $field ), [ 'status' => 400 ] );
-}
-}
+        $required = [ 'arrival', 'departure', 'email', 'first_name', 'last_name' ];
+        foreach ( $required as $field ) {
+            if ( empty( $body[ $field ] ) ) {
+                return new WP_Error( 'missing_field', sprintf( __( 'Field %s is required.', 'vr-single-property' ), $field ), [ 'status' => 400 ] );
+            }
+        }
 
-$quote = $this->pricing->calculate_quote( sanitize_text_field( $body['arrival'] ), sanitize_text_field( $body['departure'] ), absint( $body['guests'] ?? 1 ), sanitize_text_field( $body['coupon'] ?? '' ) );
+        try {
+            $arrival   = new DateTimeImmutable( sanitize_text_field( $body['arrival'] ) );
+            $departure = new DateTimeImmutable( sanitize_text_field( $body['departure'] ) );
+        } catch ( \Exception $e ) {
+            return new WP_Error( 'invalid_date', __( 'Invalid arrival or departure date.', 'vr-single-property' ), [ 'status' => 400 ] );
+        }
 
-$response = $this->stripe->create_checkout_session(
-[
-'arrival'    => sanitize_text_field( $body['arrival'] ),
-'departure'  => sanitize_text_field( $body['departure'] ),
-'guests'     => absint( $body['guests'] ?? 1 ),
-'email'      => sanitize_email( $body['email'] ),
-'phone'      => sanitize_text_field( $body['phone'] ?? '' ),
-'first_name' => sanitize_text_field( $body['first_name'] ),
-'last_name'  => sanitize_text_field( $body['last_name'] ),
-'coupon'     => sanitize_text_field( $body['coupon'] ?? '' ),
-],
-$quote
-);
+        if ( $arrival >= $departure ) {
+            return new WP_Error( 'invalid_range', __( 'Departure must be after arrival.', 'vr-single-property' ), [ 'status' => 400 ] );
+        }
 
-if ( isset( $response['error'] ) ) {
-return new WP_Error( 'stripe_error', $response['error'], [ 'status' => 500 ] );
-}
+        if ( ! $this->ical->is_range_available( $arrival, $departure ) ) {
+            return new WP_Error( 'unavailable', __( 'Those dates were just booked. Choose another range.', 'vr-single-property' ), [ 'status' => 409 ] );
+        }
 
-return new WP_REST_Response( $response );
-}
+        $quote = $this->pricing->calculate_quote( $arrival->format( 'Y-m-d' ), $departure->format( 'Y-m-d' ), absint( $body['guests'] ?? 1 ), sanitize_text_field( $body['coupon'] ?? '' ) );
 
-public function availability(): WP_REST_Response {
-$events = [];
-$bookings = get_posts(
-[
-'post_type'      => 'vrsp_booking',
-'post_status'    => [ 'publish', 'draft' ],
-'posts_per_page' => 200,
-]
-);
+        $user_id = $this->sync_guest_user(
+            [
+                'email'      => sanitize_email( $body['email'] ),
+                'first_name' => sanitize_text_field( $body['first_name'] ),
+                'last_name'  => sanitize_text_field( $body['last_name'] ),
+                'phone'      => sanitize_text_field( $body['phone'] ?? '' ),
+                'arrival'    => $arrival->format( 'Y-m-d' ),
+                'departure'  => $departure->format( 'Y-m-d' ),
+                'guests'     => absint( $body['guests'] ?? 1 ),
+            ]
+        );
 
-foreach ( $bookings as $booking ) {
-$events[] = [
-'arrival'   => get_post_meta( $booking->ID, '_vrsp_arrival', true ),
-'departure' => get_post_meta( $booking->ID, '_vrsp_departure', true ),
-'guests'    => get_post_meta( $booking->ID, '_vrsp_guests', true ),
-];
-}
+        if ( is_wp_error( $user_id ) ) {
+            return $user_id;
+        }
 
-return new WP_REST_Response( $events );
-}
+        $response = $this->stripe->create_checkout_session(
+            [
+                'arrival'    => $arrival->format( 'Y-m-d' ),
+                'departure'  => $departure->format( 'Y-m-d' ),
+                'guests'     => absint( $body['guests'] ?? 1 ),
+                'email'      => sanitize_email( $body['email'] ),
+                'phone'      => sanitize_text_field( $body['phone'] ?? '' ),
+                'first_name' => sanitize_text_field( $body['first_name'] ),
+                'last_name'  => sanitize_text_field( $body['last_name'] ),
+                'coupon'     => sanitize_text_field( $body['coupon'] ?? '' ),
+                'user_id'    => $user_id,
+            ],
+            $quote
+        );
+
+        if ( isset( $response['error'] ) ) {
+            return new WP_Error( 'stripe_error', $response['error'], [ 'status' => 500 ] );
+        }
+
+        return new WP_REST_Response(
+            array_merge(
+                $response,
+                [
+                    'pending_review' => true,
+                    'deposit'        => $quote['deposit'],
+                    'balance'        => $quote['balance'],
+                ]
+            )
+        );
+    }
+
+    public function availability( WP_REST_Request $request ): WP_REST_Response {
+        $months = absint( $request->get_param( 'months' ) );
+        if ( $months <= 0 ) {
+            $months = 6;
+        }
+        $months = min( 12, $months );
+
+        $timezone = wp_timezone();
+        $start    = new DateTimeImmutable( 'today', $timezone );
+        $end      = $start->modify( '+' . $months . ' months' );
+
+        $blocked = $this->ical->get_availability_window( $start, $end );
+        $rates   = $this->pricing->get_calendar_rates( $start, $end );
+
+        return new WP_REST_Response(
+            [
+                'blocked'  => $blocked,
+                'rates'    => $rates,
+                'currency' => $this->settings->get( 'currency', 'USD' ),
+                'updated'  => current_time( 'mysql' ),
+            ]
+        );
+    }
 
 public function stripe_webhook( WP_REST_Request $request ) {
 $ok = $this->stripe->handle_webhook( $request->get_body(), $request->get_header( 'Stripe-Signature' ) );
 return new WP_REST_Response( [ 'received' => (bool) $ok ] );
 }
 
-public function sms_webhook( WP_REST_Request $request ): WP_REST_Response {
-$payload = $request->get_json_params();
-$this->sms->handle_inbound( $payload );
-return new WP_REST_Response( [ 'received' => true ] );
-}
+    public function sms_webhook( WP_REST_Request $request ): WP_REST_Response {
+        $payload = $request->get_json_params();
+        $this->sms->handle_inbound( $payload );
+        return new WP_REST_Response( [ 'received' => true ] );
+    }
+
+    private function sync_guest_user( array $data ) {
+        $email = $data['email'];
+        if ( ! $email ) {
+            return new WP_Error( 'missing_email', __( 'Email is required.', 'vr-single-property' ), [ 'status' => 400 ] );
+        }
+
+        $user_id = email_exists( $email );
+
+        if ( ! $user_id ) {
+            $username = $this->generate_username_from_email( $email );
+            $password = wp_generate_password( 14, true );
+            $user_id  = wp_create_user( $username, $password, $email );
+
+            if ( is_wp_error( $user_id ) ) {
+                return new WP_Error( 'user_create_failed', __( 'Unable to register guest user.', 'vr-single-property' ), [ 'status' => 500 ] );
+            }
+        }
+
+        $userdata = [
+            'ID'         => (int) $user_id,
+            'first_name' => $data['first_name'],
+            'last_name'  => $data['last_name'],
+            'display_name' => trim( $data['first_name'] . ' ' . $data['last_name'] ),
+        ];
+
+        $updated = wp_update_user( $userdata );
+
+        if ( is_wp_error( $updated ) ) {
+            return new WP_Error( 'user_update_failed', __( 'Unable to update guest profile.', 'vr-single-property' ), [ 'status' => 500 ] );
+        }
+
+        if ( ! empty( $data['phone'] ) ) {
+            update_user_meta( $user_id, 'vrsp_phone', $data['phone'] );
+        }
+
+        update_user_meta( $user_id, 'vrsp_last_arrival', $data['arrival'] );
+        update_user_meta( $user_id, 'vrsp_last_departure', $data['departure'] );
+        update_user_meta( $user_id, 'vrsp_last_guests', $data['guests'] );
+
+        $user = get_userdata( $user_id );
+
+        if ( $user && ! in_array( 'vrsp_guest', (array) $user->roles, true ) ) {
+            $user->add_role( 'vrsp_guest' );
+        }
+
+        return $user_id;
+    }
+
+    private function generate_username_from_email( string $email ): string {
+        list( $local ) = explode( '@', $email );
+        $base = sanitize_user( $local, true );
+
+        if ( empty( $base ) ) {
+            $base = 'guest';
+        }
+
+        if ( ! username_exists( $base ) ) {
+            return $base;
+        }
+
+        $suffix = 1;
+        do {
+            $candidate = $base . $suffix;
+            $suffix++;
+        } while ( username_exists( $candidate ) );
+
+        return $candidate;
+    }
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -62,6 +62,7 @@ return self::$instance;
         if ( function_exists( 'load_plugin_textdomain' ) ) {
             load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
         }
+        add_role( 'vrsp_guest', __( 'Guest', 'vr-single-property' ), [ 'read' => true ] );
         RentalPostType::register_post_type();
         BasePostType::flush_rewrite();
         CronManager::activate();
@@ -88,16 +89,23 @@ LogPostType::register();
 
 $this->boot_modules();
 
-add_action( 'init', [ $this, 'load_textdomain' ] );
-add_action( 'init', [ $this->settings, 'refresh' ], 11 );
+        add_action( 'init', [ $this, 'load_textdomain' ] );
+        add_action( 'init', [ $this, 'ensure_roles' ] );
+        add_action( 'init', [ $this->settings, 'refresh' ], 11 );
 }
 
 /**
  * Load text domain.
  */
-public function load_textdomain(): void {
-load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
-}
+    public function load_textdomain(): void {
+        load_plugin_textdomain( 'vr-single-property', false, dirname( plugin_basename( VRSP_PLUGIN_FILE ) ) . '/languages/' );
+    }
+
+    public function ensure_roles(): void {
+        if ( ! get_role( 'vrsp_guest' ) ) {
+            add_role( 'vrsp_guest', __( 'Guest', 'vr-single-property' ), [ 'read' => true ] );
+        }
+    }
 
 /**
  * Boot supporting modules.

--- a/public/css/public.css
+++ b/public/css/public.css
@@ -1,106 +1,212 @@
-.vrsp-listing {
-font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-background: #ffffff;
-border-radius: 16px;
-box-shadow: 0 10px 40px rgba(15, 23, 42, 0.12);
-overflow: hidden;
-margin: 2rem auto;
-max-width: 1200px;
-}
-
-.vrsp-hero {
-display: grid;
-grid-template-columns: 2fr 1fr;
-gap: 1rem;
-}
-
-.vrsp-hero img {
-width: 100%;
-height: 100%;
-object-fit: cover;
-}
-
-.vrsp-content {
-padding: 2rem;
-display: grid;
-gap: 2rem;
+.vrsp-booking-widget {
+    display: grid;
+    gap: 1.5rem;
+    margin: 0 auto 3rem;
+    padding: 1.5rem;
+    max-width: 960px;
+    background: #ffffff;
+    border-radius: 20px;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
 }
 
 .vrsp-card {
-background: #f8fafc;
-border-radius: 12px;
-padding: 1.5rem;
-box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+    background: #f8fafc;
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
-.vrsp-grid {
-display: grid;
-gap: 1.5rem;
+.vrsp-card__header h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #0f172a;
 }
 
-.vrsp-grid.two {
-grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+.vrsp-card__header p {
+    margin: 0;
+    color: #475569;
+    font-size: 0.95rem;
 }
 
-.vrsp-calendar {
-background: #0f172a;
-color: #e2e8f0;
-padding: 1.5rem;
-border-radius: 12px;
+.vrsp-availability__calendar {
+    min-height: 160px;
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(59, 130, 246, 0.08));
+    border-radius: 12px;
+    padding: 1rem;
+    color: #1e293b;
+    display: grid;
+    gap: 0.5rem;
 }
 
-.vrsp-availability span.booked {
-display: inline-block;
-margin: 0.25rem;
-padding: 0.25rem 0.5rem;
-background: rgba(248, 113, 113, 0.15);
-color: #b91c1c;
-border-radius: 999px;
-font-size: 0.85rem;
+.vrsp-availability__calendar .vrsp-availability__tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+    font-size: 0.85rem;
 }
 
-.vrsp-form label {
-display: block;
-font-weight: 600;
-margin-bottom: 0.25rem;
+.vrsp-availability__rates h3 {
+    margin: 0 0 0.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
 }
 
-.vrsp-form input,
-.vrsp-form select {
-width: 100%;
-border-radius: 8px;
-border: 1px solid #cbd5f5;
-padding: 0.5rem 0.75rem;
-margin-bottom: 1rem;
+.vrsp-availability__base {
+    margin: 0 0 0.75rem;
+    color: #475569;
+    font-size: 0.9rem;
 }
 
-.vrsp-form button {
-background: linear-gradient(135deg, #2563eb, #1d4ed8);
-color: #fff;
-border: none;
-padding: 0.75rem 1.5rem;
-border-radius: 999px;
-font-weight: 600;
-cursor: pointer;
-transition: transform 0.15s ease, box-shadow 0.15s ease;
+.vrsp-availability__rate-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
-.vrsp-form button:hover {
-transform: translateY(-1px);
-box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+.vrsp-availability__rate-list .rate-pill {
+    display: inline-flex;
+    padding: 0.4rem 0.75rem;
+    border-radius: 12px;
+    background: #0f172a;
+    color: #e2e8f0;
+    font-weight: 600;
+    font-size: 0.85rem;
 }
 
-.vrsp-quote {
-font-size: 1.1rem;
-font-weight: 600;
-color: #0f172a;
+.vrsp-form__grid {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.vrsp-form__grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.vrsp-form__grid input {
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.5);
+    padding: 0.65rem 0.75rem;
+    font-size: 1rem;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.vrsp-form__grid input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+    outline: none;
+}
+
+.vrsp-form__submit {
+    margin-top: 0.5rem;
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    cursor: pointer;
+    box-shadow: 0 16px 30px rgba(37, 99, 235, 0.25);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.vrsp-form__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 20px 40px rgba(37, 99, 235, 0.3);
+}
+
+.vrsp-quote[hidden] {
+    display: none;
+}
+
+.vrsp-quote__grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin: 0;
+}
+
+.vrsp-quote__grid div {
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 12px;
+    padding: 0.75rem;
+}
+
+.vrsp-quote__grid dt {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.vrsp-quote__grid dd {
+    margin: 0.25rem 0 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.vrsp-quote__note {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #475569;
 }
 
 .vrsp-message {
-padding: 1rem;
-border-radius: 8px;
-margin-top: 1rem;
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    display: none;
 }
 
-.vrsp-message.error { background: #fee2e2; color: #b91c1c; }
-.vrsp-message.success { background: #dcfce7; color: #15803d; }
+.vrsp-message.error {
+    display: block;
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.vrsp-message.success {
+    display: block;
+    background: #dcfce7;
+    color: #15803d;
+}
+
+@media (min-width: 768px) {
+    .vrsp-booking-widget {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        padding: 2.5rem;
+    }
+
+    .vrsp-card--form {
+        grid-column: span 1;
+    }
+}
+
+@media (max-width: 767px) {
+    .vrsp-booking-widget {
+        border-radius: 0;
+        box-shadow: none;
+        padding: 1.25rem 1rem;
+    }
+
+    .vrsp-card {
+        border-radius: 12px;
+    }
+}

--- a/public/js/listing.js
+++ b/public/js/listing.js
@@ -1,88 +1,154 @@
-(function(){
-const root = document.querySelector('.vrsp-listing');
-if (!root || typeof vrspListing === 'undefined') {
-return;
-}
+(function () {
+    const widget = document.querySelector('.vrsp-booking-widget');
+    if (!widget || typeof vrspListing === 'undefined') {
+        return;
+    }
 
-const form = root.querySelector('.vrsp-form');
-const quoteBox = root.querySelector('.vrsp-quote');
-const message = root.querySelector('.vrsp-message');
-const availability = root.querySelector('.vrsp-availability');
+    const form = widget.querySelector('.vrsp-form');
+    const quotePanel = widget.querySelector('.vrsp-quote');
+    const message = widget.querySelector('.vrsp-message');
+    const availabilityCalendar = widget.querySelector('.vrsp-availability__calendar');
+    const rateList = widget.querySelector('.vrsp-availability__rate-list');
 
-const formatCurrency = (amount) => new Intl.NumberFormat('en-US', { style: 'currency', currency: vrspListing.currency }).format(amount || 0);
+    const currency = widget.querySelector('.vrsp-availability').getAttribute('data-currency') || 'USD';
+    const formatCurrency = (amount) => {
+        const value = Number(amount || 0);
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value);
+    };
 
-const loadAvailability = () => {
-fetch(vrspListing.api + '/availability')
-.then((res) => res.json())
-.then((events) => {
-if (!Array.isArray(events)) {
-return;
-}
-availability.innerHTML = '';
-events.forEach((event) => {
-const span = document.createElement('span');
-span.className = 'booked';
-span.textContent = `${event.arrival} → ${event.departure}`;
-availability.appendChild(span);
-});
-})
-.catch(() => {});
-};
+    const renderBlocked = (blocked) => {
+        availabilityCalendar.innerHTML = '';
 
-loadAvailability();
+        if (!Array.isArray(blocked) || blocked.length === 0) {
+            const empty = document.createElement('p');
+            empty.textContent = window.vrspListing.i18n?.availabilityEmpty || 'Your preferred dates are open!';
+            availabilityCalendar.appendChild(empty);
+            return;
+        }
 
-const submit = (e) => {
-e.preventDefault();
-message.textContent = '';
-message.className = 'vrsp-message';
+        blocked.slice(0, 8).forEach((event) => {
+            const tag = document.createElement('span');
+            tag.className = 'vrsp-availability__tag';
+            tag.textContent = `${event.start} → ${event.end}`;
+            availabilityCalendar.appendChild(tag);
+        });
+    };
 
-const payload = {
-arrival: form.arrival.value,
-departure: form.departure.value,
-guests: form.guests.value,
-coupon: form.coupon.value,
-first_name: form.first_name.value,
-last_name: form.last_name.value,
-email: form.email.value,
-phone: form.phone.value,
-};
+    const renderRates = (rates) => {
+        rateList.innerHTML = '';
+        if (!Array.isArray(rates) || rates.length === 0) {
+            return;
+        }
 
-fetch(vrspListing.api + '/quote', {
-method: 'POST',
-headers: { 'Content-Type': 'application/json' },
-body: JSON.stringify(payload),
-})
-.then((res) => res.json())
-.then((quote) => {
-if (quote.error) {
-throw new Error(quote.error);
-}
-quoteBox.textContent = `${formatCurrency(quote.total)} — ${quote.nights} nights`;
+        rates.slice(0, 6).forEach((rate) => {
+            const pill = document.createElement('span');
+            pill.className = 'rate-pill';
+            pill.textContent = `${rate.date}: ${formatCurrency(rate.amount)}`;
+            rateList.appendChild(pill);
+        });
+    };
 
-return fetch(vrspListing.api + '/booking', {
-method: 'POST',
-headers: { 'Content-Type': 'application/json' },
-body: JSON.stringify(payload),
-});
-})
-.then((res) => res.json())
-.then((resp) => {
-if (resp.error) {
-throw new Error(resp.error);
-}
-message.classList.add('success');
-message.textContent = 'Redirecting to secure checkout…';
-if (resp.checkout_url) {
-window.location.href = resp.checkout_url;
-}
-})
-.catch((err) => {
-message.classList.add('error');
-message.textContent = err.message || 'Unable to process booking. Please try again.';
-});
-};
+    const populateQuote = (quote) => {
+        if (!quote) {
+            quotePanel.hidden = true;
+            return;
+        }
 
-if (form) {
-form.addEventListener('submit', submit);
-}
+        quotePanel.hidden = false;
+        widget.querySelector('[data-quote="nights"]').textContent = quote.nights;
+        widget.querySelector('[data-quote="subtotal"]').textContent = formatCurrency(quote.subtotal);
+        const taxes = Number(quote.taxes || 0) + Number(quote.cleaning_fee || 0) + Number(quote.damage_fee || 0);
+        widget.querySelector('[data-quote="taxes"]').textContent = formatCurrency(taxes);
+        widget.querySelector('[data-quote="total"]').textContent = formatCurrency(quote.total);
+        widget.querySelector('[data-quote="deposit"]').textContent = formatCurrency(quote.deposit);
+
+        const balanceRow = widget.querySelector('[data-quote="balance-row"]');
+        if (quote.deposit >= quote.total) {
+            balanceRow.style.display = 'none';
+            widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.fullBalanceNote || 'Your stay begins soon, so the full balance is due today.';
+        } else {
+            balanceRow.style.display = '';
+            widget.querySelector('[data-quote="balance"]').textContent = formatCurrency(quote.balance);
+            widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.depositNote || 'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.';
+        }
+    };
+
+    const loadAvailability = () => {
+        fetch(`${vrspListing.api}/availability`)
+            .then((res) => res.json())
+            .then((data) => {
+                if (!data || typeof data !== 'object') {
+                    renderBlocked([]);
+                    renderRates([]);
+                    return;
+                }
+
+                renderBlocked(data.blocked || []);
+                renderRates(data.rates || []);
+            })
+            .catch(() => {
+                // Keep silent if availability fails.
+            });
+    };
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        message.className = 'vrsp-message';
+        message.textContent = '';
+
+        const payload = {
+            arrival: form.arrival.value,
+            departure: form.departure.value,
+            guests: form.guests.value,
+            coupon: form.coupon.value,
+            first_name: form.first_name.value,
+            last_name: form.last_name.value,
+            email: form.email.value,
+            phone: form.phone.value,
+        };
+
+        populateQuote(null);
+
+        fetch(`${vrspListing.api}/quote`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        })
+            .then((res) => res.json())
+            .then((quote) => {
+                if (quote.error) {
+                    throw new Error(quote.error);
+                }
+
+                populateQuote(quote);
+
+                return fetch(`${vrspListing.api}/booking`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+            })
+            .then((res) => res.json())
+            .then((response) => {
+                if (response.error) {
+                    throw new Error(response.error);
+                }
+
+                message.classList.add('success');
+                message.textContent = window.vrspListing.i18n?.redirecting || 'Redirecting to secure checkout…';
+                if (response.checkout_url) {
+                    window.location.href = response.checkout_url;
+                }
+            })
+            .catch((error) => {
+                message.classList.add('error');
+                message.textContent = error.message || window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.';
+            });
+    };
+
+    loadAvailability();
+
+    if (form) {
+        form.addEventListener('submit', handleSubmit);
+    }
 })();

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -1,95 +1,100 @@
 <?php
-/** @var WP_Post $rental */
-/** @var string $content Sanitized rental content */
-if ( ! isset( $rental ) || ! $rental instanceof WP_Post ) {
+if ( ! isset( $rental ) || ! $rental instanceof \WP_Post ) {
     return;
 }
 
-$gallery   = get_attached_media( 'image', $rental->ID );
 $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
-$content = isset( $content ) ? (string) $content : '';
-
-
-
-$content = isset( $content ) ? (string) $content : '';
-
-$content   = $rental->post_content;
-
-
-$patterns = [
-    '/\[vrsp_listing(?:\s+[^\]]*)?\](?:.*?\[\/vrsp_listing\])?/is',
-    '/<!--\s+wp:vrsp\/listing.*?-->.*?<!--\s+\/wp:vrsp\/listing\s+-->/is',
-    '/<!--\s+wp:vrsp\/listing\s+\/?-->/i',
-];
-
-foreach ( $patterns as $pattern ) {
-    $maybe = preg_replace( $pattern, '', $content );
-
-    if ( null !== $maybe ) {
-        $content = $maybe;
-    }
-}
-
-$content = trim( $content );
-
-$listing_block_class = 'VRSP\\Blocks\\ListingBlock';
-$guard_active        = class_exists( $listing_block_class ) && $listing_block_class::is_rendering();
-
-if ( $guard_active ) {
-
-if ( class_exists( '\\VRSP\\Blocks\\ListingBlock' ) && \VRSP\Blocks\ListingBlock::is_rendering() ) {
-
-    $content = wpautop( $content );
-} else {
-    $content = apply_filters( 'the_content', $content );
-}
-
-$content = wp_kses_post( $content );
-
-
-
+$currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
 ?>
-<div class="vrsp-listing">
-    <div class="vrsp-hero">
-        <?php if ( $gallery ) :
-            $images = array_slice( $gallery, 0, 4 );
-            foreach ( $images as $image ) :
-?>
-<img src="<?php echo esc_url( wp_get_attachment_image_url( $image->ID, 'large' ) ); ?>" alt="<?php echo esc_attr( get_post_meta( $image->ID, '_wp_attachment_image_alt', true ) ); ?>" />
-<?php endforeach; else : ?>
-<img src="<?php echo esc_url( VRSP_PLUGIN_URL . 'assets/placeholder.jpg' ); ?>" alt="" />
-<?php endif; ?>
-    </div>
-
-    <div class="vrsp-content">
-        <div class="vrsp-grid two">
-            <div class="vrsp-card">
-                <h2><?php echo esc_html( get_the_title( $rental ) ); ?></h2>
-                <div class="vrsp-description"><?php echo $content; ?></div>
+<div class="vrsp-booking-widget">
+    <section class="vrsp-card vrsp-card--availability">
+        <header class="vrsp-card__header">
+            <h2><?php esc_html_e( 'Check Availability', 'vr-single-property' ); ?></h2>
+            <p><?php esc_html_e( 'Always up to date with Airbnb, VRBO, and Booking.com sync.', 'vr-single-property' ); ?></p>
+        </header>
+        <div class="vrsp-availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
+            <div class="vrsp-availability__calendar" aria-live="polite"></div>
+            <div class="vrsp-availability__rates">
+                <h3><?php esc_html_e( 'Nightly preview', 'vr-single-property' ); ?></h3>
+                <p class="vrsp-availability__base"><?php printf( esc_html__( 'From %1$s %2$s nightly before fees and taxes.', 'vr-single-property' ), esc_html( $currency ), esc_html( number_format_i18n( $base_rate, 2 ) ) ); ?></p>
+                <div class="vrsp-availability__rate-list" role="list"></div>
             </div>
-            <div class="vrsp-card vrsp-calendar">
-                <h3><?php esc_html_e( 'Availability', 'vr-single-property' ); ?></h3>
-                <div class="vrsp-availability"></div>
-                <p><?php esc_html_e( 'Bookings auto-sync across Airbnb, VRBO, and Booking.com via iCal.', 'vr-single-property' ); ?></p>
-</div>
-</div>
+        </div>
+    </section>
 
-<div class="vrsp-card">
-<h3><?php esc_html_e( 'Get an Instant Quote', 'vr-single-property' ); ?></h3>
-<form class="vrsp-form">
-<label><?php esc_html_e( 'Arrival', 'vr-single-property' ); ?><input type="date" name="arrival" required /></label>
-<label><?php esc_html_e( 'Departure', 'vr-single-property' ); ?><input type="date" name="departure" required /></label>
-<label><?php esc_html_e( 'Guests', 'vr-single-property' ); ?><input type="number" name="guests" min="1" value="2" /></label>
-<label><?php esc_html_e( 'Coupon Code', 'vr-single-property' ); ?><input type="text" name="coupon" /></label>
-<label><?php esc_html_e( 'First Name', 'vr-single-property' ); ?><input type="text" name="first_name" required /></label>
-<label><?php esc_html_e( 'Last Name', 'vr-single-property' ); ?><input type="text" name="last_name" required /></label>
-<label><?php esc_html_e( 'Email', 'vr-single-property' ); ?><input type="email" name="email" required /></label>
-<label><?php esc_html_e( 'Mobile Number', 'vr-single-property' ); ?><input type="tel" name="phone" /></label>
-<button type="submit"><?php esc_html_e( 'Reserve with Stripe Checkout', 'vr-single-property' ); ?></button>
-</form>
-<div class="vrsp-quote"><?php printf( esc_html__( 'Nightly rate from %s', 'vr-single-property' ), esc_html( number_format_i18n( $base_rate, 2 ) ) ); ?></div>
-<div class="vrsp-message" aria-live="polite"></div>
-</div>
-</div>
+    <section class="vrsp-card vrsp-card--form">
+        <header class="vrsp-card__header">
+            <h2><?php esc_html_e( 'Reserve Your Stay', 'vr-single-property' ); ?></h2>
+            <p><?php esc_html_e( 'Secure checkout with Stripe. Deposits are calculated automatically.', 'vr-single-property' ); ?></p>
+        </header>
+        <form class="vrsp-form">
+            <div class="vrsp-form__grid">
+                <label>
+                    <span><?php esc_html_e( 'Arrival', 'vr-single-property' ); ?></span>
+                    <input type="date" name="arrival" required />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Departure', 'vr-single-property' ); ?></span>
+                    <input type="date" name="departure" required />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Guests', 'vr-single-property' ); ?></span>
+                    <input type="number" name="guests" min="1" value="2" />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Coupon Code', 'vr-single-property' ); ?></span>
+                    <input type="text" name="coupon" />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'First Name', 'vr-single-property' ); ?></span>
+                    <input type="text" name="first_name" required />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Last Name', 'vr-single-property' ); ?></span>
+                    <input type="text" name="last_name" required />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Email', 'vr-single-property' ); ?></span>
+                    <input type="email" name="email" required />
+                </label>
+                <label>
+                    <span><?php esc_html_e( 'Mobile Number', 'vr-single-property' ); ?></span>
+                    <input type="tel" name="phone" />
+                </label>
+            </div>
+            <button type="submit" class="vrsp-form__submit"><?php esc_html_e( 'Continue to Secure Payment', 'vr-single-property' ); ?></button>
+        </form>
+        <div class="vrsp-quote" hidden>
+            <h3><?php esc_html_e( 'Trip summary', 'vr-single-property' ); ?></h3>
+            <dl class="vrsp-quote__grid">
+                <div>
+                    <dt><?php esc_html_e( 'Nights', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="nights">—</dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e( 'Subtotal', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="subtotal">—</dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e( 'Taxes &amp; Fees', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="taxes">—</dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e( 'Total', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="total">—</dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e( 'Due Today', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="deposit">—</dd>
+                </div>
+                <div data-quote="balance-row">
+                    <dt><?php esc_html_e( 'Balance on File', 'vr-single-property' ); ?></dt>
+                    <dd data-quote="balance">—</dd>
+                </div>
+            </dl>
+            <p class="vrsp-quote__note" data-quote="note"></p>
+        </div>
+        <div class="vrsp-message" aria-live="polite"></div>
+    </section>
 </div>


### PR DESCRIPTION
## Summary
- rebuild the public booking experience around a mobile-first availability widget that surfaces nightly pricing, fees, and Stripe checkout hand-off
- tighten REST, iCal, and Stripe integrations to validate channel availability, create guest users, and stage bookings for admin approval before notifying downstream services
- expand the admin bookings view with financial breakdowns, approve-and-notify actions, and SMS alerts for new pending reservations

## Testing
- php -l includes/Utilities/class-rest-routes.php
- php -l includes/Integrations/class-ical-sync.php
- php -l includes/Integrations/class-stripe-gateway.php
- php -l includes/Integrations/class-checkin-app.php
- php -l includes/Integrations/class-sms-gateway.php
- php -l includes/Admin/class-menu.php
- php -l includes/class-plugin.php
- php -l includes/Blocks/class-listing-block.php
- php -l templates/listing/listing.php

------
https://chatgpt.com/codex/tasks/task_e_68daff03f4408324b4a3580cd0ad9670