### PR TITLE
Bump VR Single Property version to 0.1.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: vrsp
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -47,10 +47,16 @@ Set every tier uplift to `0` in **Settings → Dynamic Pricing** or place the op
 
 == Changelog ==
 
+= 0.1.1 =
+* Bump asset and plugin versions to ensure browsers load the latest scripts and styles.
+
 = 0.1.0 =
 * Initial release with payments, pricing, iCal, SMS, and check-in integration.
 
 == Upgrade Notice ==
+
+= 0.1.1 =
+Ensure browsers download the latest JavaScript and CSS by updating the versioned assets.
 
 = 0.1.0 =
 First public release.

--- a/theme-seed/functions.php
+++ b/theme-seed/functions.php
@@ -1,4 +1,4 @@
 <?php
 add_action( 'wp_enqueue_scripts', function () {
-wp_enqueue_style( 'vrsp-child', get_stylesheet_uri(), [ 'twentytwentyfour-style' ], '0.1.0' );
+wp_enqueue_style( 'vrsp-child', get_stylesheet_uri(), [ 'twentytwentyfour-style' ], '0.1.1' );
 } );

--- a/theme-seed/style.css
+++ b/theme-seed/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/jordan-view-retreat
 Template: twentytwentyfour
 Description: Starter child theme for VR Single Property listings.
 Author: VR Single Property
-Version: 0.1.0
+Version: 0.1.1
 */
 
 @import url('../twentytwentyfour/style.css');

--- a/vr-single-property.php
+++ b/vr-single-property.php
@@ -3,7 +3,7 @@
  * Plugin Name:       VR Single Property
  * Plugin URI:        https://example.com/vr-single-property
  * Description:       Single-property vacation rental system with booking, payments, dynamic pricing, and operations automations.
- * Version:           0.1.0
+ * Version:           0.1.1
  * Author:            VR Single Property
  * Author URI:        https://example.com
  * Text Domain:       vr-single-property
@@ -25,7 +25,7 @@ echo '<div class="notice notice-error"><p>' . esc_html__( 'VR Single Property re
 return;
 }
 
-define( 'VRSP_VERSION', '0.1.0' );
+define( 'VRSP_VERSION', '0.1.1' );
 define( 'VRSP_PLUGIN_FILE', __FILE__ );
 define( 'VRSP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VRSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump the plugin header and runtime version constant to 0.1.1 so enqueued assets receive a fresh cache-busting query string
- update the readme stable tag, changelog, and upgrade notice for the 0.1.1 release
- align the theme seed stylesheet metadata and enqueue version with the 0.1.1 release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2629758c8324815e2c6549972dbf