### PR TITLE
Bump plugin version to 0.1.2

### DIFF
--- a/vr-single-property.php
+++ b/vr-single-property.php
@@ -3,7 +3,7 @@
  * Plugin Name:       VR Single Property
  * Plugin URI:        https://example.com/vr-single-property
  * Description:       Single-property vacation rental system with booking, payments, dynamic pricing, and operations automations.
- * Version:           0.1.1
+ * Version:           0.1.2
  * Author:            VR Single Property
  * Author URI:        https://example.com
  * Text Domain:       vr-single-property
@@ -25,7 +25,7 @@ echo '<div class="notice notice-error"><p>' . esc_html__( 'VR Single Property re
 return;
 }
 
-define( 'VRSP_VERSION', '0.1.1' );
+define( 'VRSP_VERSION', '0.1.2' );
 define( 'VRSP_PLUGIN_FILE', __FILE__ );
 define( 'VRSP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VRSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump the plugin header version to 0.1.2 for cache busting
- synchronize the VRSP_VERSION constant with the new release number

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db32d712788324858278bfd1961465