### PR TITLE
Fix duplicate booking widget helpers

### DIFF
--- a/public/js/listing.js
+++ b/public/js/listing.js
@@ -5,21 +5,28 @@
 
     const setupWidget = (widget, listingData) => {
         if (!widget || widget.dataset.vrspReady === 'true') {
-
-    const init = () => {
-        const widget = document.querySelector('.vrsp-booking-widget');
-        if (!widget || typeof vrspListing === 'undefined') {
             return;
         }
 
-        const form = widget.querySelector('.vrsp-form');
-        const quotePanel = widget.querySelector('.vrsp-quote');
-        const message = widget.querySelector('.vrsp-message');
-        const submitButton = widget.querySelector('.vrsp-form__submit');
-        const continueButton = widget.querySelector('.vrsp-form__continue');
-        const availability = widget.querySelector('.vrsp-availability');
-        const availabilityCalendar = widget.querySelector('.vrsp-availability__calendar');
-        const rateList = widget.querySelector('.vrsp-availability__rate-list');
+        const selectors = {
+            form: listingData?.selectors?.form || '.vrsp-form',
+            quote: listingData?.selectors?.quote || '.vrsp-quote',
+            message: listingData?.selectors?.message || '.vrsp-message',
+            submit: listingData?.selectors?.submit || '.vrsp-form__submit',
+            continueButton: listingData?.selectors?.continue || '.vrsp-form__continue',
+            availability: listingData?.selectors?.availability || '.vrsp-availability',
+            availabilityCalendar: listingData?.selectors?.availabilityCalendar || '.vrsp-availability__calendar',
+            rateList: listingData?.selectors?.rateList || '.vrsp-availability__rate-list',
+        };
+
+        const form = widget.querySelector(selectors.form);
+        const quotePanel = widget.querySelector(selectors.quote);
+        const message = widget.querySelector(selectors.message);
+        const submitButton = widget.querySelector(selectors.submit);
+        const continueButton = widget.querySelector(selectors.continueButton);
+        const availability = widget.querySelector(selectors.availability);
+        const availabilityCalendar = widget.querySelector(selectors.availabilityCalendar);
+        const rateList = widget.querySelector(selectors.rateList);
 
         if (!form || !quotePanel || !submitButton || !continueButton || !availability) {
             return;
@@ -27,18 +34,12 @@
 
         const currency = availability.getAttribute('data-currency') || listingData.currency || 'USD';
 
-        const availabilityCalendar = widget.querySelector('.vrsp-availability__calendar');
-        const rateList = widget.querySelector('.vrsp-availability__rate-list');
-
-        const currency = widget.querySelector('.vrsp-availability').getAttribute('data-currency') || 'USD';
-
         const formatCurrency = (amount) => {
             const value = Number(amount || 0);
             return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value);
         };
 
         const renderBlocked = (blocked) => {
-
             if (!availabilityCalendar) {
                 return;
             }
@@ -204,146 +205,6 @@
                 .then((res) => {
                     if (!res.ok) {
                         throw new Error(getGenericError());
-
-            availabilityCalendar.innerHTML = '';
-
-            if (!Array.isArray(blocked) || blocked.length === 0) {
-                const empty = document.createElement('p');
-                empty.textContent = window.vrspListing.i18n?.availabilityEmpty || 'Your preferred dates are open!';
-                availabilityCalendar.appendChild(empty);
-                return;
-            }
-
-            blocked.slice(0, 8).forEach((event) => {
-                const tag = document.createElement('span');
-                tag.className = 'vrsp-availability__tag';
-                tag.textContent = `${event.start} → ${event.end}`;
-                availabilityCalendar.appendChild(tag);
-            });
-        };
-
-        const renderRates = (rates) => {
-            rateList.innerHTML = '';
-            if (!Array.isArray(rates) || rates.length === 0) {
-                return;
-            }
-
-            rates.slice(0, 6).forEach((rate) => {
-                const pill = document.createElement('span');
-                pill.className = 'rate-pill';
-                pill.textContent = `${rate.date}: ${formatCurrency(rate.amount)}`;
-                rateList.appendChild(pill);
-            });
-        };
-
-        const populateQuote = (quote) => {
-            if (!quote) {
-                quotePanel.hidden = true;
-                return;
-            }
-
-            quotePanel.hidden = false;
-            if (!quotePanel.hasAttribute('tabindex')) {
-                quotePanel.setAttribute('tabindex', '-1');
-            }
-            widget.querySelector('[data-quote="nights"]').textContent = quote.nights;
-            widget.querySelector('[data-quote="subtotal"]').textContent = formatCurrency(quote.subtotal);
-            const taxes = Number(quote.taxes || 0) + Number(quote.cleaning_fee || 0) + Number(quote.damage_fee || 0);
-            widget.querySelector('[data-quote="taxes"]').textContent = formatCurrency(taxes);
-            widget.querySelector('[data-quote="total"]').textContent = formatCurrency(quote.total);
-            widget.querySelector('[data-quote="deposit"]').textContent = formatCurrency(quote.deposit);
-
-            const balanceRow = widget.querySelector('[data-quote="balance-row"]');
-            if (quote.deposit >= quote.total) {
-                balanceRow.style.display = 'none';
-                widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.fullBalanceNote ||
-                    'Your stay begins soon, so the full balance is due today.';
-            } else {
-                balanceRow.style.display = '';
-                widget.querySelector('[data-quote="balance"]').textContent = formatCurrency(quote.balance);
-                widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.depositNote ||
-                    'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.';
-            }
-        };
-
-        const collectPayload = () => ({
-            arrival: form.arrival.value,
-            departure: form.departure.value,
-            guests: form.guests.value,
-            coupon: form.coupon.value,
-            first_name: form.first_name.value,
-            last_name: form.last_name.value,
-            email: form.email.value,
-            phone: form.phone.value,
-        });
-
-        const payloadsMatch = (a, b) =>
-            ['arrival', 'departure', 'guests', 'coupon', 'first_name', 'last_name', 'email', 'phone'].every(
-                (key) => String(a[key] ?? '') === String(b[key] ?? '')
-            );
-
-        const resetMessage = () => {
-            if (!message) {
-                return;
-            }
-
-            message.className = 'vrsp-message';
-            message.textContent = '';
-        };
-
-        const setButtonState = (button, disabled) => {
-            if (!button) {
-                return;
-            }
-
-            button.disabled = !!disabled;
-            if (disabled) {
-                button.setAttribute('aria-disabled', 'true');
-            } else {
-                button.removeAttribute('aria-disabled');
-            }
-        };
-
-        const loadAvailability = () => {
-            fetch(`${vrspListing.api}/availability`)
-                .then((res) => res.json())
-                .then((data) => {
-                    if (!data || typeof data !== 'object') {
-                        renderBlocked([]);
-                        renderRates([]);
-                        return;
-                    }
-
-                    renderBlocked(data.blocked || []);
-                    renderRates(data.rates || []);
-                })
-                .catch(() => {
-                    // Keep silent if availability fails.
-                });
-        };
-
-        let latestPayload = null;
-
-        const handleQuote = (event) => {
-            event.preventDefault();
-            resetMessage();
-            latestPayload = null;
-            setButtonState(continueButton, true);
-
-            const payload = collectPayload();
-
-            populateQuote(null);
-
-            setButtonState(submitButton, true);
-
-            fetch(`${vrspListing.api}/quote`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
                     }
 
                     return res.json();
@@ -368,82 +229,7 @@
 
                     if (message) {
                         message.classList.add('info');
-                        message.textContent = window.vrspListing.i18n?.quoteReady ||
-                            'Quote ready! Review the details before continuing to payment.';
-                    }
-                })
-                .catch((error) => {
-                    latestPayload = null;
-                    populateQuote(null);
-                    setButtonState(continueButton, true);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || window.vrspListing.i18n?.genericError ||
-                            'Unable to process booking. Please try again.';
-                    }
-                })
-                .finally(() => {
-                    setButtonState(submitButton, false);
-                });
-        };
-
-        const handleContinue = () => {
-            if (!continueButton) {
-                return;
-            }
-
-            if (!latestPayload) {
-                resetMessage();
-                if (message) {
-                    message.classList.add('info');
-                    message.textContent = window.vrspListing.i18n?.quoteRequired ||
-                        'Request a quote before continuing to secure payment.';
-                }
-                return;
-            }
-
-            resetMessage();
-            setButtonState(continueButton, true);
-            setButtonState(submitButton, true);
-            if (message) {
-                message.classList.add('info');
-                message.textContent = window.vrspListing.i18n?.checkoutPreparing || 'Preparing secure checkout…';
-            }
-
-            fetch(`${vrspListing.api}/booking`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(latestPayload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
-
-                    }
-
-                    return res.json();
-                })
-                .then((quote) => {
-                    if (quote.error) {
-                        throw new Error(quote.error);
-                    }
-
-                    const currentValues = collectPayload();
-                    if (!payloadsMatch(payload, currentValues)) {
-                        // Form changed while fetching a quote; ignore this response.
-                        return;
-                    }
-
-                    populateQuote(quote);
-                    latestPayload = payload;
-                    setButtonState(continueButton, false);
-                    if (!quotePanel.hidden) {
-                        quotePanel.focus({ preventScroll: true });
-                    }
-
-                    if (message) {
-                        message.classList.add('info');
-                        message.textContent = window.vrspListing?.i18n?.quoteReady ||
+                        message.textContent = listingData?.i18n?.quoteReady ||
                             'Quote ready! Review the details before continuing to payment.';
                     }
                 })
@@ -454,34 +240,10 @@
                     if (message) {
                         message.classList.add('error');
                         message.textContent = error.message || getGenericError();
-                .then((response) => {
-                    if (response.error) {
-                        throw new Error(response.error);
-                    }
-
-                    if (message) {
-                        message.classList.add('success');
-                        message.textContent = window.vrspListing.i18n?.redirecting ||
-                            'Redirecting to secure checkout…';
-                    }
-
-                    if (response.checkout_url) {
-                        window.location.href = response.checkout_url;
-                    }
-                })
-                .catch((error) => {
-                    setButtonState(continueButton, false);
-                    setButtonState(submitButton, false);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || window.vrspListing.i18n?.genericError ||
-                            'Unable to process booking. Please try again.';
-
                     }
                 })
                 .finally(() => {
                     setButtonState(submitButton, false);
-
                 });
         };
 
@@ -494,7 +256,7 @@
                 resetMessage();
                 if (message) {
                     message.classList.add('info');
-                    message.textContent = window.vrspListing?.i18n?.quoteRequired ||
+                    message.textContent = listingData?.i18n?.quoteRequired ||
                         'Request a quote before continuing to secure payment.';
                 }
                 return;
@@ -505,45 +267,8 @@
             setButtonState(submitButton, true);
             if (message) {
                 message.classList.add('info');
-                message.textContent = window.vrspListing?.i18n?.checkoutPreparing || 'Preparing secure checkout…';
+                message.textContent = listingData?.i18n?.checkoutPreparing || 'Preparing secure checkout…';
             }
-
-                    if (latestPayload) {
-                        setButtonState(continueButton, false);
-                    }
-                });
-        };
-
-        loadAvailability();
-
-        if (form) {
-            form.addEventListener('submit', handleQuote);
-            form.addEventListener('input', () => {
-                if (!latestPayload) {
-                    return;
-                }
-
-                latestPayload = null;
-                populateQuote(null);
-                setButtonState(continueButton, true);
-                resetMessage();
-            });
-        }
-
-        if (continueButton) {
-            continueButton.addEventListener('click', handleContinue);
-        }
-
-        fetch(`${vrspListing.api}/booking`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(latestPayload),
-        })
-            .then((res) => {
-                if (!res.ok) {
-                    throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
-                }
-
 
             if (!listingData.api) {
                 setButtonState(continueButton, false);
@@ -574,7 +299,7 @@
 
                     if (message) {
                         message.classList.add('success');
-                        message.textContent = window.vrspListing?.i18n?.redirecting ||
+                        message.textContent = listingData?.i18n?.redirecting ||
                             'Redirecting to secure checkout…';
                     }
 
@@ -600,19 +325,23 @@
 
         loadAvailability();
 
-        form.addEventListener('submit', handleQuote);
-        form.addEventListener('input', () => {
-            if (!latestPayload) {
-                return;
-            }
+        if (form) {
+            form.addEventListener('submit', handleQuote);
+            form.addEventListener('input', () => {
+                if (!latestPayload) {
+                    return;
+                }
 
-            latestPayload = null;
-            populateQuote(null);
-            setButtonState(continueButton, true);
-            resetMessage();
-        });
+                latestPayload = null;
+                populateQuote(null);
+                setButtonState(continueButton, true);
+                resetMessage();
+            });
+        }
 
-        continueButton.addEventListener('click', handleContinue);
+        if (continueButton) {
+            continueButton.addEventListener('click', handleContinue);
+        }
 
         widget.dataset.vrspReady = 'true';
     };
@@ -633,13 +362,6 @@
             setupWidget(widget, listingData);
         });
     };
-
-
-                }
-            });
-
-    };
-
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init, { once: true });


### PR DESCRIPTION
## Summary
- clean up the booking widget script by removing duplicate declarations and helper implementations
- ensure the widget relies on the provided listing data configuration for currency, availability, quoting, and booking calls
- respect optional listingData selector overrides when locating booking widget elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db34eabd5c8324b978f8711ba25f02