### PR TITLE
Streamline booking widget flow and bump plugin version

### DIFF
--- a/includes/Blocks/class-listing-block.php
+++ b/includes/Blocks/class-listing-block.php
@@ -129,12 +129,15 @@ class ListingBlock {
                 'rules'    => $this->rules->get_rules(),
                 'i18n'     => [
                     'availabilityEmpty' => __( 'Your preferred dates are open!', 'vr-single-property' ),
+                    'quotePrompt'       => __( 'Enter your trip details to see an instant quote.', 'vr-single-property' ),
+                    'quoteLoading'      => __( 'Fetching your quote…', 'vr-single-property' ),
                     'depositNote'       => __( 'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.', 'vr-single-property' ),
                     'fullBalanceNote'   => __( 'Your stay begins soon, so the full balance is due today.', 'vr-single-property' ),
                     'quoteReady'        => __( 'Quote ready! Review the details before continuing to payment.', 'vr-single-property' ),
                     'quoteRequired'     => __( 'Request a quote before continuing to secure payment.', 'vr-single-property' ),
                     'checkoutPreparing' => __( 'Preparing secure checkout…', 'vr-single-property' ),
                     'redirecting'       => __( 'Redirecting to secure checkout…', 'vr-single-property' ),
+                    'rateFallback'      => __( 'Nightly from %s', 'vr-single-property' ),
                     'genericError'      => __( 'Unable to process booking. Please try again.', 'vr-single-property' ),
                 ],
             ]

--- a/public/js/listing.js
+++ b/public/js/listing.js
@@ -1,649 +1,593 @@
-(function () {
-    const INIT_RETRY_LIMIT = 20;
-    const INIT_RETRY_DELAY = 150;
-    let initAttempts = 0;
+;(function (window, document) {
+    'use strict';
 
-    const setupWidget = (widget, listingData) => {
-        if (!widget || widget.dataset.vrspReady === 'true') {
+    var INIT_RETRY_LIMIT = 20;
+    var INIT_RETRY_DELAY = 150;
+    var QUOTE_DEBOUNCE = 350;
 
-    const init = () => {
-        const widget = document.querySelector('.vrsp-booking-widget');
-        if (!widget || typeof vrspListing === 'undefined') {
+    var SELECTORS = {
+        form: '[data-vrsp="form"], .vrsp-form',
+        continueButton: '[data-vrsp="continue"], .vrsp-form__continue',
+        message: '[data-vrsp="message"], .vrsp-message',
+        quotePanel: '[data-vrsp="quote"], .vrsp-quote',
+        availability: '[data-vrsp="availability"], .vrsp-availability',
+        calendar: '[data-vrsp="calendar"], .vrsp-availability__calendar',
+        rateList: '[data-vrsp="rate-list"], .vrsp-availability__rate-list'
+    };
+
+    var stateByWidget = new WeakMap();
+    var initAttempts = 0;
+    var supportsAbortController = typeof window.AbortController === 'function';
+
+    function getText(listingData, key, fallback) {
+        if (listingData && listingData.i18n && listingData.i18n[key]) {
+            return listingData.i18n[key];
+        }
+
+        return fallback;
+    }
+
+    function createFormatter(currencyCode) {
+        var code = currencyCode || 'USD';
+
+        try {
+            var formatter = new window.Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: code
+            });
+
+            return function (value) {
+                return formatter.format(Number(value || 0));
+            };
+        } catch (error) {
+            return function (value) {
+                var amount = Number(value || 0).toFixed(2);
+                return code + ' ' + amount;
+            };
+        }
+    }
+
+    function clearChildren(node) {
+        if (!node) {
             return;
         }
 
-        const form = widget.querySelector('.vrsp-form');
-        const quotePanel = widget.querySelector('.vrsp-quote');
-        const message = widget.querySelector('.vrsp-message');
-        const submitButton = widget.querySelector('.vrsp-form__submit');
-        const continueButton = widget.querySelector('.vrsp-form__continue');
-        const availability = widget.querySelector('.vrsp-availability');
-        const availabilityCalendar = widget.querySelector('.vrsp-availability__calendar');
-        const rateList = widget.querySelector('.vrsp-availability__rate-list');
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+    }
 
-        if (!form || !quotePanel || !submitButton || !continueButton || !availability) {
+    function readForm(form) {
+        if (!form) {
+            return {
+                arrival: '',
+                departure: '',
+                guests: '',
+                coupon: '',
+                first_name: '',
+                last_name: '',
+                email: '',
+                phone: ''
+            };
+        }
+
+        return {
+            arrival: form.arrival ? form.arrival.value : '',
+            departure: form.departure ? form.departure.value : '',
+            guests: form.guests ? form.guests.value : '',
+            coupon: form.coupon ? form.coupon.value : '',
+            first_name: form.first_name ? form.first_name.value : '',
+            last_name: form.last_name ? form.last_name.value : '',
+            email: form.email ? form.email.value : '',
+            phone: form.phone ? form.phone.value : ''
+        };
+    }
+
+    function hasRequiredQuoteFields(payload) {
+        return (
+            payload &&
+            payload.arrival &&
+            payload.departure &&
+            payload.first_name &&
+            payload.last_name &&
+            payload.email
+        );
+    }
+
+    function setButtonDisabled(button, disabled) {
+        if (!button) {
             return;
         }
 
-        const currency = availability.getAttribute('data-currency') || listingData.currency || 'USD';
+        button.disabled = !!disabled;
 
-        const availabilityCalendar = widget.querySelector('.vrsp-availability__calendar');
-        const rateList = widget.querySelector('.vrsp-availability__rate-list');
+        if (disabled) {
+            button.setAttribute('aria-disabled', 'true');
+        } else {
+            button.removeAttribute('aria-disabled');
+        }
+    }
 
-        const currency = widget.querySelector('.vrsp-availability').getAttribute('data-currency') || 'USD';
+    function writeMessage(state, type, text) {
+        var node = state.message;
 
-        const formatCurrency = (amount) => {
-            const value = Number(amount || 0);
-            return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value);
-        };
+        if (!node) {
+            return;
+        }
 
-        const renderBlocked = (blocked) => {
+        node.className = 'vrsp-message';
 
-            if (!availabilityCalendar) {
-                return;
-            }
+        if (!text) {
+            node.textContent = '';
+            return;
+        }
 
-            availabilityCalendar.innerHTML = '';
+        node.classList.add(type);
+        node.textContent = text;
+    }
 
-            if (!Array.isArray(blocked) || blocked.length === 0) {
-                const empty = document.createElement('p');
-                empty.textContent = window.vrspListing?.i18n?.availabilityEmpty || 'Your preferred dates are open!';
-                availabilityCalendar.appendChild(empty);
-                return;
-            }
+    function updateQuote(state, quote) {
+        var panel = state.quotePanel;
+        var formatCurrency = state.formatCurrency;
 
-            blocked.slice(0, 8).forEach((event) => {
-                const tag = document.createElement('span');
-                tag.className = 'vrsp-availability__tag';
-                tag.textContent = `${event.start} → ${event.end}`;
-                availabilityCalendar.appendChild(tag);
-            });
-        };
+        if (!panel) {
+            return;
+        }
 
-        const renderRates = (rates) => {
-            if (!rateList) {
-                return;
-            }
+        if (!quote) {
+            panel.hidden = true;
+            return;
+        }
 
-            rateList.innerHTML = '';
-            if (!Array.isArray(rates) || rates.length === 0) {
-                return;
-            }
+        panel.hidden = false;
 
-            rates.slice(0, 6).forEach((rate) => {
-                const pill = document.createElement('span');
-                pill.className = 'rate-pill';
-                pill.textContent = `${rate.date}: ${formatCurrency(rate.amount)}`;
-                rateList.appendChild(pill);
-            });
-        };
-
-        const populateQuote = (quote) => {
-            if (!quote) {
-                quotePanel.hidden = true;
-                return;
-            }
-
-            quotePanel.hidden = false;
-            if (!quotePanel.hasAttribute('tabindex')) {
-                quotePanel.setAttribute('tabindex', '-1');
-            }
-            widget.querySelector('[data-quote="nights"]').textContent = quote.nights;
-            widget.querySelector('[data-quote="subtotal"]').textContent = formatCurrency(quote.subtotal);
-            const taxes = Number(quote.taxes || 0) + Number(quote.cleaning_fee || 0) + Number(quote.damage_fee || 0);
-            widget.querySelector('[data-quote="taxes"]').textContent = formatCurrency(taxes);
-            widget.querySelector('[data-quote="total"]').textContent = formatCurrency(quote.total);
-            widget.querySelector('[data-quote="deposit"]').textContent = formatCurrency(quote.deposit);
-
-            const balanceRow = widget.querySelector('[data-quote="balance-row"]');
-            if (balanceRow) {
-                if (quote.deposit >= quote.total) {
-                    balanceRow.style.display = 'none';
-                    widget.querySelector('[data-quote="note"]').textContent = window.vrspListing?.i18n?.fullBalanceNote ||
-                        'Your stay begins soon, so the full balance is due today.';
-                } else {
-                    balanceRow.style.display = '';
-                    widget.querySelector('[data-quote="balance"]').textContent = formatCurrency(quote.balance);
-                    widget.querySelector('[data-quote="note"]').textContent = window.vrspListing?.i18n?.depositNote ||
-                        'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.';
-                }
+        var write = function (key, value) {
+            var target = state.quoteTargets[key];
+            if (target) {
+                target.textContent = value;
             }
         };
 
-        const collectPayload = () => ({
-            arrival: form.arrival.value,
-            departure: form.departure.value,
-            guests: form.guests.value,
-            coupon: form.coupon.value,
-            first_name: form.first_name.value,
-            last_name: form.last_name.value,
-            email: form.email.value,
-            phone: form.phone.value,
-        });
+        write('nights', quote.nights || '—');
+        write('subtotal', formatCurrency(quote.subtotal || 0));
 
-        const payloadsMatch = (a, b) =>
-            ['arrival', 'departure', 'guests', 'coupon', 'first_name', 'last_name', 'email', 'phone'].every(
-                (key) => String(a[key] ?? '') === String(b[key] ?? '')
+        var taxes = 0;
+        taxes += Number(quote.taxes || 0);
+        taxes += Number(quote.cleaning_fee || 0);
+        taxes += Number(quote.damage_fee || 0);
+        write('taxes', formatCurrency(taxes));
+
+        write('total', formatCurrency(quote.total || 0));
+        write('deposit', formatCurrency(quote.deposit || 0));
+
+        if (quote.deposit && quote.total && Number(quote.deposit) < Number(quote.total)) {
+            state.balanceRow.style.display = '';
+            write('balance', formatCurrency(quote.balance || 0));
+            state.note.textContent = getText(
+                state.listingData,
+                'depositNote',
+                'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.'
             );
-
-        const resetMessage = () => {
-            if (!message) {
-                return;
-            }
-
-            message.className = 'vrsp-message';
-            message.textContent = '';
-        };
-
-        const setButtonState = (button, disabled) => {
-            if (!button) {
-                return;
-            }
-
-            button.disabled = !!disabled;
-            if (disabled) {
-                button.setAttribute('aria-disabled', 'true');
-            } else {
-                button.removeAttribute('aria-disabled');
-            }
-        };
-
-        const getGenericError = () =>
-            listingData?.i18n?.genericError || 'Unable to process booking. Please try again.';
-
-        const loadAvailability = () => {
-            if (!listingData.api) {
-                return;
-            }
-
-            fetch(`${listingData.api}/availability`)
-                .then((res) => res.json())
-                .then((data) => {
-                    if (!data || typeof data !== 'object') {
-                        renderBlocked([]);
-                        renderRates([]);
-                        return;
-                    }
-
-                    renderBlocked(data.blocked || []);
-                    renderRates(data.rates || []);
-                })
-                .catch(() => {
-                    // Keep silent if availability fails.
-                });
-        };
-
-        let latestPayload = null;
-
-        const handleQuote = (event) => {
-            event.preventDefault();
-            resetMessage();
-            latestPayload = null;
-            setButtonState(continueButton, true);
-
-            const payload = collectPayload();
-
-            populateQuote(null);
-
-            setButtonState(submitButton, true);
-
-            if (!listingData.api) {
-                setButtonState(submitButton, false);
-                if (message) {
-                    message.classList.add('error');
-                    message.textContent = getGenericError();
-                }
-                return;
-            }
-
-            fetch(`${listingData.api}/quote`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(getGenericError());
-
-            availabilityCalendar.innerHTML = '';
-
-            if (!Array.isArray(blocked) || blocked.length === 0) {
-                const empty = document.createElement('p');
-                empty.textContent = window.vrspListing.i18n?.availabilityEmpty || 'Your preferred dates are open!';
-                availabilityCalendar.appendChild(empty);
-                return;
-            }
-
-            blocked.slice(0, 8).forEach((event) => {
-                const tag = document.createElement('span');
-                tag.className = 'vrsp-availability__tag';
-                tag.textContent = `${event.start} → ${event.end}`;
-                availabilityCalendar.appendChild(tag);
-            });
-        };
-
-        const renderRates = (rates) => {
-            rateList.innerHTML = '';
-            if (!Array.isArray(rates) || rates.length === 0) {
-                return;
-            }
-
-            rates.slice(0, 6).forEach((rate) => {
-                const pill = document.createElement('span');
-                pill.className = 'rate-pill';
-                pill.textContent = `${rate.date}: ${formatCurrency(rate.amount)}`;
-                rateList.appendChild(pill);
-            });
-        };
-
-        const populateQuote = (quote) => {
-            if (!quote) {
-                quotePanel.hidden = true;
-                return;
-            }
-
-            quotePanel.hidden = false;
-            if (!quotePanel.hasAttribute('tabindex')) {
-                quotePanel.setAttribute('tabindex', '-1');
-            }
-            widget.querySelector('[data-quote="nights"]').textContent = quote.nights;
-            widget.querySelector('[data-quote="subtotal"]').textContent = formatCurrency(quote.subtotal);
-            const taxes = Number(quote.taxes || 0) + Number(quote.cleaning_fee || 0) + Number(quote.damage_fee || 0);
-            widget.querySelector('[data-quote="taxes"]').textContent = formatCurrency(taxes);
-            widget.querySelector('[data-quote="total"]').textContent = formatCurrency(quote.total);
-            widget.querySelector('[data-quote="deposit"]').textContent = formatCurrency(quote.deposit);
-
-            const balanceRow = widget.querySelector('[data-quote="balance-row"]');
-            if (quote.deposit >= quote.total) {
-                balanceRow.style.display = 'none';
-                widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.fullBalanceNote ||
-                    'Your stay begins soon, so the full balance is due today.';
-            } else {
-                balanceRow.style.display = '';
-                widget.querySelector('[data-quote="balance"]').textContent = formatCurrency(quote.balance);
-                widget.querySelector('[data-quote="note"]').textContent = window.vrspListing.i18n?.depositNote ||
-                    'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.';
-            }
-        };
-
-        const collectPayload = () => ({
-            arrival: form.arrival.value,
-            departure: form.departure.value,
-            guests: form.guests.value,
-            coupon: form.coupon.value,
-            first_name: form.first_name.value,
-            last_name: form.last_name.value,
-            email: form.email.value,
-            phone: form.phone.value,
-        });
-
-        const payloadsMatch = (a, b) =>
-            ['arrival', 'departure', 'guests', 'coupon', 'first_name', 'last_name', 'email', 'phone'].every(
-                (key) => String(a[key] ?? '') === String(b[key] ?? '')
+        } else {
+            state.balanceRow.style.display = 'none';
+            state.note.textContent = getText(
+                state.listingData,
+                'fullBalanceNote',
+                'Your stay begins soon, so the full balance is due today.'
             );
+        }
+    }
 
-        const resetMessage = () => {
-            if (!message) {
-                return;
-            }
+    function renderAvailability(state, payload) {
+        var calendar = state.calendar;
+        var rateList = state.rateList;
+        var formatCurrency = state.formatCurrency;
 
-            message.className = 'vrsp-message';
-            message.textContent = '';
-        };
+        if (calendar) {
+            clearChildren(calendar);
 
-        const setButtonState = (button, disabled) => {
-            if (!button) {
-                return;
-            }
+            var blocked = (payload && payload.blocked) || [];
 
-            button.disabled = !!disabled;
-            if (disabled) {
-                button.setAttribute('aria-disabled', 'true');
+            if (!blocked.length) {
+                var message = document.createElement('p');
+                message.textContent = getText(state.listingData, 'availabilityEmpty', 'Your preferred dates are open!');
+                calendar.appendChild(message);
             } else {
-                button.removeAttribute('aria-disabled');
-            }
-        };
-
-        const loadAvailability = () => {
-            fetch(`${vrspListing.api}/availability`)
-                .then((res) => res.json())
-                .then((data) => {
-                    if (!data || typeof data !== 'object') {
-                        renderBlocked([]);
-                        renderRates([]);
-                        return;
+                var limit = Math.min(blocked.length, 8);
+                for (var i = 0; i < limit; i += 1) {
+                    var windowItem = blocked[i];
+                    if (!windowItem) {
+                        continue;
                     }
 
-                    renderBlocked(data.blocked || []);
-                    renderRates(data.rates || []);
-                })
-                .catch(() => {
-                    // Keep silent if availability fails.
-                });
-        };
-
-        let latestPayload = null;
-
-        const handleQuote = (event) => {
-            event.preventDefault();
-            resetMessage();
-            latestPayload = null;
-            setButtonState(continueButton, true);
-
-            const payload = collectPayload();
-
-            populateQuote(null);
-
-            setButtonState(submitButton, true);
-
-            fetch(`${vrspListing.api}/quote`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
-                    }
-
-                    return res.json();
-                })
-                .then((quote) => {
-                    if (quote.error) {
-                        throw new Error(quote.error);
-                    }
-
-                    const currentValues = collectPayload();
-                    if (!payloadsMatch(payload, currentValues)) {
-                        // Form changed while fetching a quote; ignore this response.
-                        return;
-                    }
-
-                    populateQuote(quote);
-                    latestPayload = payload;
-                    setButtonState(continueButton, false);
-                    if (!quotePanel.hidden) {
-                        quotePanel.focus({ preventScroll: true });
-                    }
-
-                    if (message) {
-                        message.classList.add('info');
-                        message.textContent = window.vrspListing.i18n?.quoteReady ||
-                            'Quote ready! Review the details before continuing to payment.';
-                    }
-                })
-                .catch((error) => {
-                    latestPayload = null;
-                    populateQuote(null);
-                    setButtonState(continueButton, true);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || window.vrspListing.i18n?.genericError ||
-                            'Unable to process booking. Please try again.';
-                    }
-                })
-                .finally(() => {
-                    setButtonState(submitButton, false);
-                });
-        };
-
-        const handleContinue = () => {
-            if (!continueButton) {
-                return;
-            }
-
-            if (!latestPayload) {
-                resetMessage();
-                if (message) {
-                    message.classList.add('info');
-                    message.textContent = window.vrspListing.i18n?.quoteRequired ||
-                        'Request a quote before continuing to secure payment.';
+                    var tag = document.createElement('span');
+                    tag.className = 'vrsp-availability__tag';
+                    tag.textContent = windowItem.start + ' → ' + windowItem.end;
+                    calendar.appendChild(tag);
                 }
+            }
+        }
+
+        if (rateList) {
+            clearChildren(rateList);
+
+            var rates = (payload && payload.rates) || [];
+
+            if (!rates.length) {
+                var fallback = document.createElement('span');
+                fallback.className = 'rate-pill';
+                var pattern = getText(state.listingData, 'rateFallback', 'Nightly from %s');
+                fallback.textContent = pattern.replace('%s', formatCurrency(state.baseRate || 0));
+                rateList.appendChild(fallback);
                 return;
             }
 
-            resetMessage();
-            setButtonState(continueButton, true);
-            setButtonState(submitButton, true);
-            if (message) {
-                message.classList.add('info');
-                message.textContent = window.vrspListing.i18n?.checkoutPreparing || 'Preparing secure checkout…';
-            }
-
-            fetch(`${vrspListing.api}/booking`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(latestPayload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
-
-                    }
-
-                    return res.json();
-                })
-                .then((quote) => {
-                    if (quote.error) {
-                        throw new Error(quote.error);
-                    }
-
-                    const currentValues = collectPayload();
-                    if (!payloadsMatch(payload, currentValues)) {
-                        // Form changed while fetching a quote; ignore this response.
-                        return;
-                    }
-
-                    populateQuote(quote);
-                    latestPayload = payload;
-                    setButtonState(continueButton, false);
-                    if (!quotePanel.hidden) {
-                        quotePanel.focus({ preventScroll: true });
-                    }
-
-                    if (message) {
-                        message.classList.add('info');
-                        message.textContent = window.vrspListing?.i18n?.quoteReady ||
-                            'Quote ready! Review the details before continuing to payment.';
-                    }
-                })
-                .catch((error) => {
-                    latestPayload = null;
-                    populateQuote(null);
-                    setButtonState(continueButton, true);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || getGenericError();
-                .then((response) => {
-                    if (response.error) {
-                        throw new Error(response.error);
-                    }
-
-                    if (message) {
-                        message.classList.add('success');
-                        message.textContent = window.vrspListing.i18n?.redirecting ||
-                            'Redirecting to secure checkout…';
-                    }
-
-                    if (response.checkout_url) {
-                        window.location.href = response.checkout_url;
-                    }
-                })
-                .catch((error) => {
-                    setButtonState(continueButton, false);
-                    setButtonState(submitButton, false);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || window.vrspListing.i18n?.genericError ||
-                            'Unable to process booking. Please try again.';
-
-                    }
-                })
-                .finally(() => {
-                    setButtonState(submitButton, false);
-
-                });
-        };
-
-        const handleContinue = () => {
-            if (!continueButton) {
-                return;
-            }
-
-            if (!latestPayload) {
-                resetMessage();
-                if (message) {
-                    message.classList.add('info');
-                    message.textContent = window.vrspListing?.i18n?.quoteRequired ||
-                        'Request a quote before continuing to secure payment.';
+            var maxRates = Math.min(rates.length, 6);
+            for (var j = 0; j < maxRates; j += 1) {
+                var rate = rates[j];
+                if (!rate) {
+                    continue;
                 }
-                return;
-            }
 
-            resetMessage();
-            setButtonState(continueButton, true);
-            setButtonState(submitButton, true);
-            if (message) {
-                message.classList.add('info');
-                message.textContent = window.vrspListing?.i18n?.checkoutPreparing || 'Preparing secure checkout…';
+                var pill = document.createElement('span');
+                pill.className = 'rate-pill';
+                pill.textContent = rate.date + ': ' + formatCurrency(rate.amount);
+                rateList.appendChild(pill);
             }
+        }
+    }
 
-                    if (latestPayload) {
-                        setButtonState(continueButton, false);
-                    }
-                });
+    function fetchAvailability(state) {
+        var listingData = state.listingData;
+
+        if (!listingData || !listingData.api) {
+            renderAvailability(state, {});
+            return;
+        }
+
+        fetch(listingData.api + '/availability')
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Failed');
+                }
+                return response.json();
+            })
+            .then(function (data) {
+                renderAvailability(state, data || {});
+            })
+            .catch(function () {
+                renderAvailability(state, {});
+            });
+    }
+
+    function scheduleQuote(state) {
+        if (state.quoteTimer) {
+            window.clearTimeout(state.quoteTimer);
+        }
+
+        state.quoteTimer = window.setTimeout(function () {
+            state.quoteTimer = null;
+            requestQuote(state);
+        }, QUOTE_DEBOUNCE);
+    }
+
+    function requestQuote(state) {
+        var listingData = state.listingData;
+        var payload = readForm(state.form);
+
+        if (!hasRequiredQuoteFields(payload)) {
+            state.latestPayload = null;
+            state.latestQuote = null;
+            if (state.quoteAbort && supportsAbortController) {
+                state.quoteAbort.abort();
+            }
+            state.quoteAbort = null;
+            updateQuote(state, null);
+            setButtonDisabled(state.continueButton, true);
+            writeMessage(
+                state,
+                'info',
+                getText(listingData, 'quotePrompt', 'Enter your trip details to see an instant quote.')
+            );
+            return;
+        }
+
+        if (!listingData || !listingData.api) {
+            state.latestPayload = null;
+            state.latestQuote = null;
+            updateQuote(state, null);
+            setButtonDisabled(state.continueButton, true);
+            writeMessage(state, 'error', getText(listingData, 'genericError', 'Unable to process booking. Please try again.'));
+            return;
+        }
+
+        setButtonDisabled(state.continueButton, true);
+        writeMessage(state, 'info', getText(listingData, 'quoteLoading', 'Fetching your quote…'));
+
+        if (state.quoteAbort && supportsAbortController) {
+            state.quoteAbort.abort();
+        }
+
+        var controller = supportsAbortController ? new window.AbortController() : null;
+        state.quoteAbort = controller;
+
+        var options = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
         };
 
-        loadAvailability();
+        if (controller) {
+            options.signal = controller.signal;
+        }
 
-        if (form) {
-            form.addEventListener('submit', handleQuote);
-            form.addEventListener('input', () => {
-                if (!latestPayload) {
+        fetch(listingData.api + '/quote', options)
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error(getText(listingData, 'genericError', 'Unable to process booking. Please try again.'));
+                }
+                return response.json();
+            })
+            .then(function (quote) {
+                state.latestPayload = payload;
+                state.latestQuote = quote;
+                updateQuote(state, quote);
+                setButtonDisabled(state.continueButton, false);
+                writeMessage(
+                    state,
+                    'success',
+                    getText(listingData, 'quoteReady', 'Quote ready! Review the details before continuing to payment.')
+                );
+            })
+            .catch(function (error) {
+                if (controller && error && error.name === 'AbortError') {
                     return;
                 }
 
-                latestPayload = null;
-                populateQuote(null);
-                setButtonState(continueButton, true);
-                resetMessage();
+                state.latestPayload = null;
+                state.latestQuote = null;
+                updateQuote(state, null);
+                setButtonDisabled(state.continueButton, true);
+                var fallback = getText(listingData, 'genericError', 'Unable to process booking. Please try again.');
+                writeMessage(state, 'error', (error && error.message) || fallback);
+            })
+            .finally(function () {
+                if (state.quoteAbort === controller) {
+                    state.quoteAbort = null;
+                }
             });
+    }
+
+    function continueToCheckout(state) {
+        var listingData = state.listingData;
+        var payload = state.latestPayload;
+
+        if (!payload) {
+            writeMessage(
+                state,
+                'info',
+                getText(listingData, 'quoteRequired', 'Request a quote before continuing to secure payment.')
+            );
+            return;
         }
 
-        if (continueButton) {
-            continueButton.addEventListener('click', handleContinue);
+        if (!listingData || !listingData.api) {
+            writeMessage(state, 'error', getText(listingData, 'genericError', 'Unable to process booking. Please try again.'));
+            return;
         }
 
-        fetch(`${vrspListing.api}/booking`, {
+        setButtonDisabled(state.continueButton, true);
+        writeMessage(state, 'info', getText(listingData, 'checkoutPreparing', 'Preparing secure checkout…'));
+
+        fetch(listingData.api + '/booking', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(latestPayload),
+            body: JSON.stringify(payload)
         })
-            .then((res) => {
-                if (!res.ok) {
-                    throw new Error(window.vrspListing.i18n?.genericError || 'Unable to process booking. Please try again.');
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error(getText(listingData, 'genericError', 'Unable to process booking. Please try again.'));
+                }
+                return response.json();
+            })
+            .then(function (data) {
+                if (data && data.error) {
+                    throw new Error(data.error);
                 }
 
+                writeMessage(state, 'success', getText(listingData, 'redirecting', 'Redirecting to secure checkout…'));
 
-            if (!listingData.api) {
-                setButtonState(continueButton, false);
-                setButtonState(submitButton, false);
-                if (message) {
-                    message.classList.add('error');
-                    message.textContent = getGenericError();
+                if (data && data.checkout_url) {
+                    window.location.href = data.checkout_url;
                 }
-                return;
+            })
+            .catch(function (error) {
+                setButtonDisabled(state.continueButton, false);
+                var fallback = getText(listingData, 'genericError', 'Unable to process booking. Please try again.');
+                writeMessage(state, 'error', (error && error.message) || fallback);
+            });
+    }
+
+    function collectQuoteTargets(widget) {
+        var fields = ['nights', 'subtotal', 'taxes', 'total', 'deposit', 'balance'];
+        var targets = {};
+
+        for (var i = 0; i < fields.length; i += 1) {
+            var field = fields[i];
+            targets[field] = widget.querySelector('[data-quote="' + field + '"]');
+        }
+
+        return targets;
+    }
+
+    function mountWidget(widget, listingData) {
+        if (!widget) {
+            return;
+        }
+
+        var form = widget.querySelector(SELECTORS.form);
+        var continueButtons = widget.querySelectorAll(SELECTORS.continueButton);
+        var continueButton = continueButtons.length ? continueButtons[0] : null;
+        var quotePanel = widget.querySelector(SELECTORS.quotePanel);
+        var message = widget.querySelector(SELECTORS.message);
+        var availability = widget.querySelector(SELECTORS.availability);
+        var calendar = widget.querySelector(SELECTORS.calendar);
+        var rateList = widget.querySelector(SELECTORS.rateList);
+
+        if (continueButtons.length > 1) {
+            for (var i = 1; i < continueButtons.length; i += 1) {
+                var duplicate = continueButtons[i];
+                if (duplicate && duplicate.parentNode) {
+                    duplicate.parentNode.removeChild(duplicate);
+                }
+            }
+        }
+
+        if (!form || !continueButton || !quotePanel) {
+            return;
+        }
+
+        var currency = 'USD';
+        var baseRate = 0;
+
+        if (availability) {
+            var currencyAttr = availability.getAttribute('data-currency');
+            if (currencyAttr) {
+                currency = currencyAttr;
+            } else if (listingData && listingData.currency) {
+                currency = listingData.currency;
             }
 
-            fetch(`${listingData.api}/booking`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(latestPayload),
-            })
-                .then((res) => {
-                    if (!res.ok) {
-                        throw new Error(getGenericError());
-                    }
+            var baseAttr = availability.getAttribute('data-base-rate');
+            if (baseAttr) {
+                var parsedBase = parseFloat(baseAttr);
+                baseRate = isNaN(parsedBase) ? 0 : parsedBase;
+            }
+        } else if (listingData && listingData.currency) {
+            currency = listingData.currency;
+        }
 
-                    return res.json();
-                })
-                .then((response) => {
-                    if (response.error) {
-                        throw new Error(response.error);
-                    }
-
-                    if (message) {
-                        message.classList.add('success');
-                        message.textContent = window.vrspListing?.i18n?.redirecting ||
-                            'Redirecting to secure checkout…';
-                    }
-
-                    if (response.checkout_url) {
-                        window.location.href = response.checkout_url;
-                    }
-                })
-                .catch((error) => {
-                    setButtonState(continueButton, false);
-                    setButtonState(submitButton, false);
-                    if (message) {
-                        message.classList.add('error');
-                        message.textContent = error.message || getGenericError();
-                    }
-                })
-                .finally(() => {
-                    setButtonState(submitButton, false);
-                    if (latestPayload) {
-                        setButtonState(continueButton, false);
-                    }
-                });
+        var state = {
+            widget: widget,
+            listingData: listingData,
+            form: form,
+            continueButton: continueButton,
+            message: message,
+            quotePanel: quotePanel,
+            availability: availability,
+            calendar: calendar,
+            rateList: rateList,
+            baseRate: baseRate,
+            formatCurrency: createFormatter(currency),
+            quoteTargets: collectQuoteTargets(widget),
+            balanceRow: widget.querySelector('[data-quote="balance-row"]') || document.createElement('div'),
+            note: widget.querySelector('[data-quote="note"]') || document.createElement('p'),
+            latestPayload: null,
+            latestQuote: null,
+            quoteTimer: null,
+            quoteAbort: null
         };
 
-        loadAvailability();
-
-        form.addEventListener('submit', handleQuote);
-        form.addEventListener('input', () => {
-            if (!latestPayload) {
-                return;
-            }
-
-            latestPayload = null;
-            populateQuote(null);
-            setButtonState(continueButton, true);
-            resetMessage();
+        form.addEventListener('submit', function (event) {
+            event.preventDefault();
         });
 
-        continueButton.addEventListener('click', handleContinue);
+        var onFormChange = function () {
+            state.latestPayload = null;
+            state.latestQuote = null;
+            updateQuote(state, null);
+            setButtonDisabled(state.continueButton, true);
+            writeMessage(state, '', '');
+            if (state.quoteAbort && supportsAbortController) {
+                state.quoteAbort.abort();
+                state.quoteAbort = null;
+            }
+            scheduleQuote(state);
+        };
 
-        widget.dataset.vrspReady = 'true';
-    };
+        form.addEventListener('input', onFormChange);
+        form.addEventListener('change', onFormChange);
 
-    const init = () => {
-        const listingData = window.vrspListing;
-        const widgets = document.querySelectorAll('.vrsp-booking-widget');
+        continueButton.addEventListener('click', function () {
+            continueToCheckout(state);
+        });
+
+        stateByWidget.set(widget, state);
+
+        setButtonDisabled(state.continueButton, true);
+        fetchAvailability(state);
+        requestQuote(state);
+    }
+
+    function refreshState(widget, listingData) {
+        var state = stateByWidget.get(widget);
+        if (!state) {
+            mountWidget(widget, listingData);
+            return;
+        }
+
+        state.listingData = listingData;
+
+        var availability = state.availability;
+        var currency = listingData && listingData.currency ? listingData.currency : 'USD';
+        var baseRate = state.baseRate;
+
+        if (availability) {
+            var currencyAttr = availability.getAttribute('data-currency');
+            if (currencyAttr) {
+                currency = currencyAttr;
+            }
+
+            var baseAttr = availability.getAttribute('data-base-rate');
+            if (baseAttr) {
+                var parsedBase = parseFloat(baseAttr);
+                baseRate = isNaN(parsedBase) ? baseRate : parsedBase;
+            }
+        }
+
+        state.baseRate = baseRate;
+        state.formatCurrency = createFormatter(currency);
+
+        fetchAvailability(state);
+        requestQuote(state);
+    }
+
+    function init(refreshOnly) {
+        var listingData = window.vrspListing;
+        var widgets = document.querySelectorAll('[data-vrsp-widget], .vrsp-booking-widget');
 
         if (!widgets.length || typeof listingData === 'undefined') {
-            if (initAttempts < INIT_RETRY_LIMIT) {
+            if (!refreshOnly && initAttempts < INIT_RETRY_LIMIT) {
                 initAttempts += 1;
-                window.setTimeout(init, INIT_RETRY_DELAY);
+                window.setTimeout(function () {
+                    init(false);
+                }, INIT_RETRY_DELAY);
             }
             return;
         }
 
-        widgets.forEach((widget) => {
-            setupWidget(widget, listingData);
-        });
+        for (var i = 0; i < widgets.length; i += 1) {
+            refreshState(widgets[i], listingData);
+        }
+    }
+
+    window.vrspBookingWidget = {
+        init: init,
+        refresh: function () {
+            init(true);
+        },
+        version: '1.2.0'
     };
-
-
-                }
-            });
-
-    };
-
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init, { once: true });
+        document.addEventListener(
+            'DOMContentLoaded',
+            function () {
+                init(false);
+            },
+            { once: true }
+        );
     } else {
-        init();
+        init(false);
     }
-})();
+})(window, document);

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -7,17 +7,17 @@ $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
 $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
 ?>
-<div class="vrsp-booking-widget">
+<div class="vrsp-booking-widget" data-vrsp-widget>
     <section class="vrsp-card vrsp-card--availability">
         <header class="vrsp-card__header">
             <h2><?php esc_html_e( 'Check Availability', 'vr-single-property' ); ?></h2>
         </header>
-        <div class="vrsp-availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
-            <div class="vrsp-availability__calendar" aria-live="polite"></div>
+        <div class="vrsp-availability" data-vrsp="availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
+            <div class="vrsp-availability__calendar" data-vrsp="calendar" aria-live="polite"></div>
             <div class="vrsp-availability__rates">
                 <h3><?php esc_html_e( 'Nightly preview', 'vr-single-property' ); ?></h3>
                 <p class="vrsp-availability__base"><?php printf( esc_html__( 'From %1$s %2$s nightly before fees and taxes.', 'vr-single-property' ), esc_html( $currency ), esc_html( number_format_i18n( $base_rate, 2 ) ) ); ?></p>
-                <div class="vrsp-availability__rate-list" role="list"></div>
+                <div class="vrsp-availability__rate-list" data-vrsp="rate-list" role="list"></div>
             </div>
         </div>
     </section>
@@ -25,9 +25,9 @@ $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
     <section class="vrsp-card vrsp-card--form">
         <header class="vrsp-card__header">
             <h2><?php esc_html_e( 'Reserve Your Stay', 'vr-single-property' ); ?></h2>
-            <p><?php esc_html_e( 'Request a quote to review nightly rates, fees, and deposit requirements before continuing to secure payment with Stripe.', 'vr-single-property' ); ?></p>
+            <p><?php esc_html_e( 'Enter your stay details to see live pricing. When it looks good, continue to secure payment.', 'vr-single-property' ); ?></p>
         </header>
-        <form class="vrsp-form">
+        <form class="vrsp-form" data-vrsp="form">
             <div class="vrsp-form__grid">
                 <label>
                     <span><?php esc_html_e( 'Arrival', 'vr-single-property' ); ?></span>
@@ -63,13 +63,12 @@ $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
                 </label>
             </div>
             <div class="vrsp-form__actions">
-                <button type="submit" class="vrsp-form__submit"><?php esc_html_e( 'Get Quote', 'vr-single-property' ); ?></button>
-                <button type="button" class="vrsp-form__continue" disabled><?php esc_html_e( 'Continue to Secure Payment', 'vr-single-property' ); ?></button>
+                <button type="button" class="vrsp-form__continue" data-vrsp="continue" disabled><?php esc_html_e( 'Continue to Secure Payment', 'vr-single-property' ); ?></button>
             </div>
         </form>
-        <div class="vrsp-quote" hidden>
+        <div class="vrsp-quote" data-vrsp="quote" hidden>
             <h3><?php esc_html_e( 'Trip summary', 'vr-single-property' ); ?></h3>
-            <p class="vrsp-quote__intro"><?php esc_html_e( 'Review the quote below. When everything looks good, continue to secure your payment.', 'vr-single-property' ); ?></p>
+            <p class="vrsp-quote__intro"><?php esc_html_e( 'Pricing updates automatically as you edit your stay. Review the summary before continuing to secure payment.', 'vr-single-property' ); ?></p>
             <dl class="vrsp-quote__grid">
                 <div>
                     <dt><?php esc_html_e( 'Nights', 'vr-single-property' ); ?></dt>
@@ -98,6 +97,6 @@ $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
             </dl>
             <p class="vrsp-quote__note" data-quote="note"></p>
         </div>
-        <div class="vrsp-message" aria-live="polite"></div>
+        <div class="vrsp-message" data-vrsp="message" aria-live="polite"></div>
     </section>
 </div>

--- a/vr-single-property.php
+++ b/vr-single-property.php
@@ -3,7 +3,7 @@
  * Plugin Name:       VR Single Property
  * Plugin URI:        https://example.com/vr-single-property
  * Description:       Single-property vacation rental system with booking, payments, dynamic pricing, and operations automations.
- * Version:           0.1.2
+ * Version:           0.1.8
  * Author:            VR Single Property
  * Author URI:        https://example.com
  * Text Domain:       vr-single-property
@@ -25,7 +25,7 @@ echo '<div class="notice notice-error"><p>' . esc_html__( 'VR Single Property re
 return;
 }
 
-define( 'VRSP_VERSION', '0.1.2' );
+define( 'VRSP_VERSION', '0.1.8' );
 define( 'VRSP_PLUGIN_FILE', __FILE__ );
 define( 'VRSP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VRSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- rebuild the front-end booking widget as a lean, single-mount module that auto-refreshes availability and quotes without redeclaration conflicts
- add a localized fallback rate label and simplify the listing template messaging to emphasise the streamlined experience
- bump the plugin version to 0.1.8 so refreshed assets are delivered to WordPress clients

## Testing
- node --check public/js/listing.js
- php -l templates/listing/listing.php
- php -l includes/Blocks/class-listing-block.php
- php -l vr-single-property.php

------
https://chatgpt.com/codex/tasks/task_e_68db34eabd5c8324b978f8711ba25f02