### PR TITLE
Fix clearChildren helper to prevent SyntaxError

### DIFF
--- a/public/js/listing.js
+++ b/public/js/listing.js
@@ -53,9 +53,6 @@
         if (!node) {
             return;
         }
-        return fallback;
-    }
-
         while (node.firstChild) {
             node.removeChild(node.firstChild);
         }


### PR DESCRIPTION
## Summary
- remove an erroneous fallback return from clearChildren to restore valid syntax in listing.js
- ensure the widget script executes without throwing a syntax error during initialization

## Testing
- node -e "new Function(require('fs').readFileSync('public/js/listing.js','utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68dc1e826600832497d5a96bb602886a