### PR TITLE
Add rental metadata management and VacationRental schema

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -4,9 +4,65 @@ return;
 }
 
 $values = get_option( \VRSP\Settings::OPTION_KEY, $settings->get_defaults() );
+$rental_id = function_exists( 'vrsp_get_primary_rental_id' ) ? vrsp_get_primary_rental_id() : 0;
+$rental    = $rental_id ? get_post( $rental_id ) : null;
+$rental_meta = $rental instanceof WP_Post ? \VRSP\PostTypes\RentalPostType::get_rental_meta( $rental_id ) : \VRSP\PostTypes\RentalPostType::get_meta_defaults();
+$amenities_value = ! empty( $rental_meta['vrsp_amenities'] ) ? implode( "\n", (array) $rental_meta['vrsp_amenities'] ) : '';
+$regulatory_value = ! empty( $rental_meta['vrsp_regulatory_ids'] ) ? implode( "\n", (array) $rental_meta['vrsp_regulatory_ids'] ) : '';
 ?>
 <div class="wrap vrsp-admin">
 <h1><?php esc_html_e( 'VR Single Property Settings', 'vr-single-property' ); ?></h1>
+<?php if ( $rental instanceof WP_Post ) : ?>
+<h2><?php esc_html_e( 'Rental Profile', 'vr-single-property' ); ?></h2>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="vrsp-admin__rental-profile">
+<?php wp_nonce_field( 'vrsp_save_rental_profile', '_vrsp_rental_profile_nonce' ); ?>
+<input type="hidden" name="action" value="vrsp_save_rental_profile" />
+<input type="hidden" name="rental_id" value="<?php echo esc_attr( $rental_id ); ?>" />
+<table class="form-table" role="presentation">
+<tr>
+<th scope="row"><?php esc_html_e( 'Rental', 'vr-single-property' ); ?></th>
+<td><strong><?php echo esc_html( get_the_title( $rental ) ); ?></strong> <a href="<?php echo esc_url( get_edit_post_link( $rental_id ) ); ?>"><?php esc_html_e( 'Edit', 'vr-single-property' ); ?></a></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Street address', 'vr-single-property' ); ?></th>
+<td><textarea name="vrsp_meta[vrsp_address]" rows="3" class="large-text"><?php echo esc_textarea( $rental_meta['vrsp_address'] ?? '' ); ?></textarea></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Latitude', 'vr-single-property' ); ?></th>
+<td><input type="number" name="vrsp_meta[vrsp_latitude]" step="any" value="<?php echo esc_attr( null !== $rental_meta['vrsp_latitude'] ? $rental_meta['vrsp_latitude'] : '' ); ?>" /></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Longitude', 'vr-single-property' ); ?></th>
+<td><input type="number" name="vrsp_meta[vrsp_longitude]" step="any" value="<?php echo esc_attr( null !== $rental_meta['vrsp_longitude'] ? $rental_meta['vrsp_longitude'] : '' ); ?>" /></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Maximum guests', 'vr-single-property' ); ?></th>
+<td><input type="number" name="vrsp_meta[vrsp_max_guests]" min="0" step="1" value="<?php echo esc_attr( null !== $rental_meta['vrsp_max_guests'] ? $rental_meta['vrsp_max_guests'] : '' ); ?>" /></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Property type', 'vr-single-property' ); ?></th>
+<td><input type="text" name="vrsp_meta[vrsp_property_type]" class="regular-text" value="<?php echo esc_attr( $rental_meta['vrsp_property_type'] ?? '' ); ?>" /></td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Amenities', 'vr-single-property' ); ?></th>
+<td>
+<textarea name="vrsp_meta[vrsp_amenities]" rows="4" class="large-text"><?php echo esc_textarea( $amenities_value ); ?></textarea>
+<p class="description"><?php esc_html_e( 'Enter one amenity per line.', 'vr-single-property' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Regulatory IDs', 'vr-single-property' ); ?></th>
+<td>
+<textarea name="vrsp_meta[vrsp_regulatory_ids]" rows="3" class="large-text"><?php echo esc_textarea( $regulatory_value ); ?></textarea>
+<p class="description"><?php esc_html_e( 'Enter one ID per line.', 'vr-single-property' ); ?></p>
+</td>
+</tr>
+</table>
+<?php submit_button( __( 'Save Rental Profile', 'vr-single-property' ) ); ?>
+</form>
+<?php else : ?>
+<div class="notice notice-warning inline"><p><?php esc_html_e( 'Publish a rental to manage its profile information here.', 'vr-single-property' ); ?></p></div>
+<?php endif; ?>
 <form method="post" action="options.php">
 <?php settings_fields( 'vrsp_settings' ); ?>
 <table class="form-table" role="presentation">

--- a/includes/PostTypes/class-rental-post-type.php
+++ b/includes/PostTypes/class-rental-post-type.php
@@ -1,6 +1,7 @@
 <?php
 namespace VRSP\PostTypes;
 
+use WP_Post;
 use function __;
 use function did_action;
 
@@ -8,12 +9,49 @@ use function did_action;
  * Rental post type.
  */
 class RentalPostType extends BasePostType {
+    private const NONCE_ACTION = 'vrsp_rental_details';
+    private const NONCE_NAME   = '_vrsp_rental_details_nonce';
+
+    private const META_FIELDS = [
+        'vrsp_address'        => [
+            'type'      => 'textarea',
+            'rest_type' => 'string',
+        ],
+        'vrsp_latitude'       => [
+            'type'      => 'float',
+            'rest_type' => 'number',
+        ],
+        'vrsp_longitude'      => [
+            'type'      => 'float',
+            'rest_type' => 'number',
+        ],
+        'vrsp_max_guests'     => [
+            'type'      => 'int',
+            'rest_type' => 'integer',
+        ],
+        'vrsp_property_type'  => [
+            'type'      => 'text',
+            'rest_type' => 'string',
+        ],
+        'vrsp_amenities'      => [
+            'type'      => 'list',
+            'rest_type' => 'array',
+        ],
+        'vrsp_regulatory_ids' => [
+            'type'      => 'list',
+            'rest_type' => 'array',
+        ],
+    ];
+
     public static function get_key(): string {
         return 'vrsp_rental';
     }
 
     public static function register(): void {
         add_action( 'init', [ static::class, 'register_post_type' ] );
+        add_action( 'init', [ static::class, 'register_meta' ] );
+        add_action( 'add_meta_boxes', [ static::class, 'register_meta_boxes' ] );
+        add_action( 'save_post_' . self::get_key(), [ static::class, 'save_meta' ], 10, 2 );
     }
 
     public static function register_post_type(): void {
@@ -21,16 +59,6 @@ class RentalPostType extends BasePostType {
             self::get_key(),
             [
                 'labels'              => self::get_labels(),
-
-
-
-
-
-                'labels'       => self::get_labels(),
-
-
-
-
                 'public'              => true,
                 'show_ui'             => true,
                 'show_in_menu'        => 'vrsp-dashboard',
@@ -65,5 +93,202 @@ class RentalPostType extends BasePostType {
             'not_found_in_trash' => $translate ? __( 'No rentals found in Trash', 'vr-single-property' ) : 'No rentals found in Trash',
             'menu_name'          => $translate ? __( 'Rentals', 'vr-single-property' ) : 'Rentals',
         ];
+    }
+
+    public static function register_meta(): void {
+        foreach ( self::META_FIELDS as $meta_key => $config ) {
+            register_post_meta(
+                self::get_key(),
+                $meta_key,
+                [
+                    'single'            => true,
+                    'show_in_rest'      => true,
+                    'type'              => $config['rest_type'],
+                    'sanitize_callback' => function ( $value ) use ( $meta_key ) {
+                        return RentalPostType::sanitize_meta_value( $meta_key, $value );
+                    },
+                    'auth_callback'     => '__return_true',
+                ]
+            );
+        }
+    }
+
+    public static function register_meta_boxes(): void {
+        add_meta_box(
+            'vrsp_rental_details',
+            __( 'Rental Details', 'vr-single-property' ),
+            [ static::class, 'render_meta_box' ],
+            self::get_key(),
+            'normal',
+            'high'
+        );
+    }
+
+    public static function render_meta_box( WP_Post $post ): void {
+        wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
+
+        $values = self::get_rental_meta( $post->ID );
+        ?>
+        <table class="form-table" role="presentation">
+            <tbody>
+            <tr>
+                <th scope="row"><label for="vrsp_address"><?php esc_html_e( 'Street address', 'vr-single-property' ); ?></label></th>
+                <td>
+                    <textarea class="large-text" rows="3" name="vrsp_meta[vrsp_address]" id="vrsp_address"><?php echo esc_textarea( $values['vrsp_address'] ?? '' ); ?></textarea>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_latitude"><?php esc_html_e( 'Latitude', 'vr-single-property' ); ?></label></th>
+                <td><input type="number" step="any" name="vrsp_meta[vrsp_latitude]" id="vrsp_latitude" value="<?php echo esc_attr( null !== $values['vrsp_latitude'] ? $values['vrsp_latitude'] : '' ); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_longitude"><?php esc_html_e( 'Longitude', 'vr-single-property' ); ?></label></th>
+                <td><input type="number" step="any" name="vrsp_meta[vrsp_longitude]" id="vrsp_longitude" value="<?php echo esc_attr( null !== $values['vrsp_longitude'] ? $values['vrsp_longitude'] : '' ); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_max_guests"><?php esc_html_e( 'Maximum guests', 'vr-single-property' ); ?></label></th>
+                <td><input type="number" min="0" step="1" name="vrsp_meta[vrsp_max_guests]" id="vrsp_max_guests" value="<?php echo esc_attr( null !== $values['vrsp_max_guests'] ? $values['vrsp_max_guests'] : '' ); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_property_type"><?php esc_html_e( 'Property type', 'vr-single-property' ); ?></label></th>
+                <td><input type="text" class="regular-text" name="vrsp_meta[vrsp_property_type]" id="vrsp_property_type" value="<?php echo esc_attr( $values['vrsp_property_type'] ?? '' ); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_amenities"><?php esc_html_e( 'Amenities', 'vr-single-property' ); ?></label></th>
+                <td>
+                    <textarea class="large-text" rows="4" name="vrsp_meta[vrsp_amenities]" id="vrsp_amenities"><?php echo esc_textarea( implode( "\n", $values['vrsp_amenities'] ?? [] ) ); ?></textarea>
+                    <p class="description"><?php esc_html_e( 'Enter one amenity per line.', 'vr-single-property' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="vrsp_regulatory_ids"><?php esc_html_e( 'Regulatory IDs', 'vr-single-property' ); ?></label></th>
+                <td>
+                    <textarea class="large-text" rows="3" name="vrsp_meta[vrsp_regulatory_ids]" id="vrsp_regulatory_ids"><?php echo esc_textarea( implode( "\n", $values['vrsp_regulatory_ids'] ?? [] ) ); ?></textarea>
+                    <p class="description"><?php esc_html_e( 'Enter one ID per line.', 'vr-single-property' ); ?></p>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <?php
+    }
+
+    public static function save_meta( int $post_id, WP_Post $post ): void {
+        if ( self::get_key() !== $post->post_type ) {
+            return;
+        }
+
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        if ( ! isset( $_POST[ self::NONCE_NAME ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ self::NONCE_NAME ] ) ), self::NONCE_ACTION ) ) {
+            return;
+        }
+
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+
+        $raw = isset( $_POST['vrsp_meta'] ) ? (array) wp_unslash( $_POST['vrsp_meta'] ) : [];
+
+        foreach ( self::META_FIELDS as $meta_key => $config ) {
+            $value     = $raw[ $meta_key ] ?? null;
+            $sanitized = self::sanitize_meta_value( $meta_key, $value );
+
+            if ( null === $sanitized || ( is_string( $sanitized ) && '' === $sanitized ) || ( is_array( $sanitized ) && [] === $sanitized ) ) {
+                delete_post_meta( $post_id, $meta_key );
+            } else {
+                update_post_meta( $post_id, $meta_key, $sanitized );
+            }
+        }
+    }
+
+    public static function get_meta_defaults(): array {
+        return [
+            'vrsp_address'        => '',
+            'vrsp_latitude'       => null,
+            'vrsp_longitude'      => null,
+            'vrsp_max_guests'     => null,
+            'vrsp_property_type'  => '',
+            'vrsp_amenities'      => [],
+            'vrsp_regulatory_ids' => [],
+        ];
+    }
+
+    public static function get_rental_meta( int $post_id ): array {
+        $defaults = self::get_meta_defaults();
+
+        foreach ( array_keys( self::META_FIELDS ) as $meta_key ) {
+            $stored = get_post_meta( $post_id, $meta_key, true );
+            $value  = self::sanitize_meta_value( $meta_key, $stored );
+
+            if ( null !== $value ) {
+                $defaults[ $meta_key ] = $value;
+            }
+        }
+
+        return $defaults;
+    }
+
+    public static function sanitize_meta_value( string $meta_key, $value ) {
+        if ( ! isset( self::META_FIELDS[ $meta_key ] ) ) {
+            return null;
+        }
+
+        $type = self::META_FIELDS[ $meta_key ]['type'];
+
+        switch ( $type ) {
+            case 'textarea':
+                $value = is_scalar( $value ) ? sanitize_textarea_field( (string) $value ) : '';
+                return '' !== $value ? $value : '';
+            case 'text':
+                $value = is_scalar( $value ) ? sanitize_text_field( (string) $value ) : '';
+                return '' !== $value ? $value : '';
+            case 'float':
+                if ( is_array( $value ) ) {
+                    $value = reset( $value );
+                }
+                $value = is_scalar( $value ) ? (string) $value : '';
+                $value = str_replace( ',', '.', $value );
+                if ( '' === trim( $value ) || ! is_numeric( $value ) ) {
+                    return null;
+                }
+                return (float) $value;
+            case 'int':
+                if ( is_array( $value ) ) {
+                    $value = reset( $value );
+                }
+                $value = is_scalar( $value ) ? (int) $value : 0;
+                return $value > 0 ? $value : null;
+            case 'list':
+                return self::sanitize_list( $value );
+        }
+
+        return null;
+    }
+
+    /**
+     * Sanitize newline-separated list values.
+     *
+     * @param mixed $value Raw value.
+     */
+    private static function sanitize_list( $value ): array {
+        if ( is_string( $value ) ) {
+            $items = preg_split( "/\r?\n/", $value );
+        } elseif ( is_array( $value ) ) {
+            $items = $value;
+        } else {
+            $items = [];
+        }
+
+        $items = array_map( static function ( $item ) {
+            return sanitize_text_field( (string) $item );
+        }, $items );
+
+        $items = array_filter( array_map( 'trim', $items ), static function ( $item ) {
+            return '' !== $item;
+        } );
+
+        return array_values( $items );
     }
 }

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -6,13 +6,40 @@ if ( ! isset( $rental ) || ! $rental instanceof \WP_Post ) {
 $options   = get_option( \VRSP\Settings::OPTION_KEY, [] );
 $base_rate = isset( $options['base_rate'] ) ? (float) $options['base_rate'] : 200;
 $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
+
+$title   = get_the_title( $rental );
+$excerpt = get_the_excerpt( $rental );
 ?>
-<div class="vrsp-booking-widget" data-vrsp-widget>
-    <section class="vrsp-card vrsp-card--availability">
-        <header class="vrsp-card__header">
-            <h2><?php esc_html_e( 'Check Availability', 'vr-single-property' ); ?></h2>
-        </header>
-        <div class="vrsp-availability" data-vrsp="availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
+
+<article class="vrsp-listing" aria-labelledby="vrsp-listing-title">
+    <header class="vrsp-listing__header">
+        <?php if ( $title ) : ?>
+            <h1 id="vrsp-listing-title" class="vrsp-listing__title"><?php echo esc_html( $title ); ?></h1>
+        <?php endif; ?>
+
+        <?php if ( $excerpt ) : ?>
+            <div class="vrsp-listing__excerpt"><?php echo wp_kses_post( $excerpt ); ?></div>
+        <?php endif; ?>
+
+        <?php if ( has_post_thumbnail( $rental ) ) : ?>
+            <figure class="vrsp-listing__featured-image">
+                <?php echo get_the_post_thumbnail( $rental, 'large' ); ?>
+            </figure>
+        <?php endif; ?>
+    </header>
+
+    <?php if ( ! empty( $content ) ) : ?>
+        <section class="vrsp-listing__details">
+            <?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content sanitized upstream. ?>
+        </section>
+    <?php endif; ?>
+
+    <div class="vrsp-booking-widget" data-vrsp-widget>
+        <section class="vrsp-card vrsp-card--availability">
+            <header class="vrsp-card__header">
+                <h2><?php esc_html_e( 'Check Availability', 'vr-single-property' ); ?></h2>
+            </header>
+            <div class="vrsp-availability" data-vrsp="availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
             <div class="vrsp-availability__calendar" data-vrsp="calendar" aria-live="polite"></div>
             <div class="vrsp-availability__details">
                 <div class="vrsp-availability__dates">
@@ -127,5 +154,18 @@ $currency  = isset( $options['currency'] ) ? $options['currency'] : 'USD';
             </div>
         </form>
         <div class="vrsp-message" data-vrsp="message" aria-live="polite"></div>
+        </section>
+    </div>
+</article>
+
+<?php if ( ! empty( $block_content ) ) : ?>
+    <section class="vrsp-listing__supplemental">
+        <?php echo wp_kses_post( $block_content ); ?>
     </section>
-</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $schema ) ) : ?>
+    <script type="application/ld+json">
+        <?php echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ); ?>
+    </script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- restructure the listing template to surface property content before the booking widget and emit JSON-LD markup
- register and expose rental profile metadata with meta boxes, REST visibility, and an admin settings editor
- build a VacationRental schema payload from rental metadata plus pricing endpoints for structured data consumers

## Testing
- php -l templates/listing/listing.php
- php -l includes/PostTypes/class-rental-post-type.php
- php -l includes/Admin/class-menu.php
- php -l admin/views/settings.php
- php -l includes/Blocks/class-listing-block.php

------
https://chatgpt.com/codex/tasks/task_e_68df058b01d88324b86bef7269943fc2