### PR TITLE
Streamline rental availability workflow

### DIFF
--- a/includes/Blocks/class-listing-block.php
+++ b/includes/Blocks/class-listing-block.php
@@ -131,6 +131,13 @@ class ListingBlock {
                 'rules'    => $this->rules->get_rules(),
                 'i18n'     => [
                     'availabilityEmpty' => __( 'Your preferred dates are open!', 'vr-single-property' ),
+                    'availabilityPrompt' => __( 'Start by selecting your check-in and checkout dates.', 'vr-single-property' ),
+                    'availabilityChecking' => __( 'Checking availability…', 'vr-single-property' ),
+                    'availabilityAvailable' => __( 'Great news! Your dates are available.', 'vr-single-property' ),
+                    'availabilityUnavailable' => __( 'Those dates are unavailable. Please choose another stay.', 'vr-single-property' ),
+                    'availabilitySuggestion' => __( 'Next available stay: %1$s to %2$s.', 'vr-single-property' ),
+                    'availabilityNoSuggestion' => __( "We'll follow up shortly with the next available dates.", 'vr-single-property' ),
+                    'availabilityApply' => __( 'Use these dates', 'vr-single-property' ),
                     'quotePrompt'       => __( 'Select arrival and departure dates to see pricing.', 'vr-single-property' ),
                     'quoteLoading'      => __( 'Calculating pricing…', 'vr-single-property' ),
                     'depositNote'       => __( 'We will automatically charge the saved payment method 7 days prior to arrival for the remaining balance.', 'vr-single-property' ),

--- a/public/css/public.css
+++ b/public/css/public.css
@@ -38,6 +38,65 @@
     font-size: 0.95rem;
 }
 
+.vrsp-card--dates .vrsp-availability {
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.1), rgba(59, 130, 246, 0.08));
+}
+
+.vrsp-availability {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1.25rem;
+    border-radius: 12px;
+    background-color: rgba(37, 99, 235, 0.06);
+}
+
+.vrsp-availability__status {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.vrsp-availability__suggestion {
+    font-size: 0.95rem;
+    color: #475569;
+}
+
+.vrsp-availability__apply {
+    justify-self: start;
+    border: none;
+    border-radius: 999px;
+    padding: 0.5rem 1.25rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    background: linear-gradient(135deg, #2563eb, #4f46e5);
+    color: #ffffff;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.vrsp-availability__apply:hover,
+.vrsp-availability__apply:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+    outline: none;
+}
+
+.vrsp-availability__apply:focus-visible {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
+}
+
+.vrsp-availability.is-checking .vrsp-availability__status {
+    color: #2563eb;
+}
+
+.vrsp-availability.is-available .vrsp-availability__status {
+    color: #047857;
+}
+
+.vrsp-availability.is-unavailable .vrsp-availability__status,
+.vrsp-availability.is-error .vrsp-availability__status {
+    color: #b91c1c;
+}
+
 .vrsp-availability__calendar {
     min-height: 160px;
     background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(59, 130, 246, 0.08));
@@ -64,6 +123,14 @@
     display: grid;
     gap: 1.25rem;
     margin-top: 1rem;
+}
+
+.vrsp-form__summary {
+    margin-top: 1.5rem;
+}
+
+.vrsp-form__summary .vrsp-availability__details {
+    margin-top: 0;
 }
 
 .vrsp-availability__dates h3,

--- a/public/js/listing.js
+++ b/public/js/listing.js
@@ -156,6 +156,62 @@
         node.textContent = text;
     }
 
+    function formatSuggestionRange(state, suggestion) {
+        if (!suggestion || !suggestion.start || !suggestion.end) {
+            return '';
+        }
+
+        var listingData = state ? state.listingData : null;
+        var template = getText(listingData, 'availabilitySuggestion', 'Next available stay: %1$s to %2$s.');
+        var startLabel = formatDate(suggestion.start);
+        var endLabel = formatDate(suggestion.end);
+
+        return template.replace('%1$s', startLabel).replace('%2$s', endLabel);
+    }
+
+    function setAvailabilityState(state, type, message, suggestionText, suggestionRange) {
+        if (!state || !state.availability) {
+            return;
+        }
+
+        var container = state.availability;
+        var classes = ['is-available', 'is-unavailable', 'is-idle', 'is-checking', 'is-error'];
+
+        for (var i = 0; i < classes.length; i += 1) {
+            container.classList.remove(classes[i]);
+        }
+
+        if (type) {
+            container.classList.add('is-' + type);
+        }
+
+        if (state.availabilityStatus) {
+            state.availabilityStatus.textContent = message || '';
+        }
+
+        if (state.availabilitySuggestion) {
+            state.availabilitySuggestion.textContent = suggestionText || '';
+        }
+
+        if (state.availabilityApply) {
+            if (suggestionRange && suggestionRange.start && suggestionRange.end) {
+                state.availabilityApply.hidden = false;
+                state.availabilityApply.textContent = getText(state.listingData, 'availabilityApply', 'Use these dates');
+            } else {
+                state.availabilityApply.hidden = true;
+            }
+        }
+
+        state.suggestedRange = suggestionRange && suggestionRange.start && suggestionRange.end
+            ? {
+                  start: suggestionRange.start,
+                  end: suggestionRange.end
+              }
+            : null;
+
+        state.availabilityStatusType = type || '';
+    }
+
     function parseISODate(value) {
         if (!value || typeof value !== 'string') {
             return null;
@@ -278,6 +334,128 @@
         }
 
         return diff;
+    }
+
+    function addDays(date, days) {
+        if (!(date instanceof Date)) {
+            return null;
+        }
+
+        var clone = new Date(date.getTime());
+        clone.setDate(clone.getDate() + days);
+        return clone;
+    }
+
+    function toISODate(date) {
+        if (!(date instanceof Date)) {
+            return '';
+        }
+
+        var month = (date.getMonth() + 1).toString().padStart(2, '0');
+        var day = date.getDate().toString().padStart(2, '0');
+
+        return date.getFullYear() + '-' + month + '-' + day;
+    }
+
+    function buildBlockedRanges(blocked) {
+        if (!Array.isArray(blocked)) {
+            return [];
+        }
+
+        var ranges = [];
+
+        for (var i = 0; i < blocked.length; i += 1) {
+            var windowItem = blocked[i];
+            if (!windowItem) {
+                continue;
+            }
+
+            var start = parseISODate(windowItem.start);
+            var end = parseISODate(windowItem.end);
+
+            if (!start || !end || !(start instanceof Date) || !(end instanceof Date)) {
+                continue;
+            }
+
+            if (start.getTime() >= end.getTime()) {
+                continue;
+            }
+
+            ranges.push({
+                start: start,
+                end: end
+            });
+        }
+
+        ranges.sort(function (a, b) {
+            return a.start.getTime() - b.start.getTime();
+        });
+
+        return ranges;
+    }
+
+    function findNextAvailableRange(blockedRanges, arrival, departure) {
+        if (!(arrival instanceof Date) || !(departure instanceof Date)) {
+            return null;
+        }
+
+        var nights = differenceInDays(arrival, departure);
+        if (nights === null || nights <= 0) {
+            return null;
+        }
+
+        var blocked = Array.isArray(blockedRanges) ? blockedRanges : [];
+        if (!blocked.length) {
+            return null;
+        }
+        var maxIterations = 365;
+        var candidateStart = new Date(arrival.getTime());
+
+        for (var i = 0; i < maxIterations; i += 1) {
+            var candidateEnd = addDays(candidateStart, nights);
+            if (!(candidateEnd instanceof Date)) {
+                break;
+            }
+
+            var conflict = false;
+            var skipTo = null;
+
+            for (var j = 0; j < blocked.length; j += 1) {
+                var range = blocked[j];
+                if (!range || !(range.start instanceof Date) || !(range.end instanceof Date)) {
+                    continue;
+                }
+
+                if (candidateEnd <= range.start || candidateStart >= range.end) {
+                    continue;
+                }
+
+                conflict = true;
+
+                if (!skipTo || range.end > skipTo) {
+                    skipTo = new Date(range.end.getTime());
+                }
+            }
+
+            if (!conflict) {
+                return {
+                    start: candidateStart,
+                    end: candidateEnd
+                };
+            }
+
+            if (!skipTo) {
+                skipTo = addDays(candidateStart, 1);
+            }
+
+            if (!(skipTo instanceof Date)) {
+                break;
+            }
+
+            candidateStart = skipTo;
+        }
+
+        return null;
     }
 
     function roundCurrency(value) {
@@ -574,31 +752,22 @@
     }
 
     function renderAvailability(state, payload) {
-        var calendar = state.calendar;
+        if (!state) {
+            return;
+        }
 
-        if (calendar) {
-            clearChildren(calendar);
+        var data = payload || {};
+        state.availabilityData = data;
+        state.blockedRanges = buildBlockedRanges(data.blocked || []);
 
-            var blocked = (payload && payload.blocked) || [];
-
-            if (!blocked.length) {
-                var message = document.createElement('p');
-                message.textContent = getText(state.listingData, 'availabilityEmpty', 'Your preferred dates are open!');
-                calendar.appendChild(message);
-            } else {
-                var limit = Math.min(blocked.length, 8);
-                for (var i = 0; i < limit; i += 1) {
-                    var windowItem = blocked[i];
-                    if (!windowItem) {
-                        continue;
-                    }
-
-                    var tag = document.createElement('span');
-                    tag.className = 'vrsp-availability__tag';
-                    tag.textContent = windowItem.start + ' → ' + windowItem.end;
-                    calendar.appendChild(tag);
-                }
-            }
+        if (!state.availabilityStatusType) {
+            setAvailabilityState(
+                state,
+                'idle',
+                getText(state.listingData, 'availabilityPrompt', 'Start by selecting your check-in and checkout dates.'),
+                '',
+                null
+            );
         }
     }
 
@@ -652,11 +821,25 @@
                 'info',
                 getText(listingData, 'quotePrompt', 'Select arrival and departure dates to see pricing.')
             );
+            setAvailabilityState(
+                state,
+                'idle',
+                getText(listingData, 'availabilityPrompt', 'Start by selecting your check-in and checkout dates.'),
+                '',
+                null
+            );
             return;
         }
 
         setButtonDisabled(state.continueButton, true);
         writeMessage(state, 'info', getText(listingData, 'quoteLoading', 'Calculating pricing…'));
+        setAvailabilityState(
+            state,
+            'checking',
+            getText(listingData, 'availabilityChecking', 'Checking availability…'),
+            '',
+            null
+        );
 
         if (state.quoteAbort && supportsAbortController) {
             state.quoteAbort.abort();
@@ -677,16 +860,37 @@
 
         fetch(listingData.api + '/quote', options)
             .then(function (response) {
-                if (!response.ok) {
-                    throw new Error(getText(listingData, 'genericError', 'Unable to process booking. Please try again.'));
-                }
-                return response.json();
+                return response
+                    .json()
+                    .catch(function () {
+                        return {};
+                    })
+                    .then(function (data) {
+                        if (!response.ok) {
+                            var message = (data && data.error)
+                                ? data.error
+                                : getText(listingData, 'genericError', 'Unable to process booking. Please try again.');
+                            var error = new Error(message);
+                            error.status = response.status;
+                            error.data = data;
+                            throw error;
+                        }
+
+                        return data;
+                    });
             })
             .then(function (quote) {
                 state.latestPayload = Object.assign({}, payload);
                 state.latestQuote = quote;
 
                 writePricing(state, payload, quote);
+                setAvailabilityState(
+                    state,
+                    'available',
+                    getText(listingData, 'availabilityAvailable', 'Great news! Your dates are available.'),
+                    '',
+                    null
+                );
 
                 if (quote && quote.coupon_error) {
                     setButtonDisabled(state.continueButton, true);
@@ -725,6 +929,43 @@
                 resetPricing(state);
 
                 var fallback = getText(listingData, 'genericError', 'Unable to process booking. Please try again.');
+
+                if (error && error.status === 409) {
+                    var unavailableMessage = error.message || getText(
+                        listingData,
+                        'availabilityUnavailable',
+                        'Those dates are unavailable. Please choose another stay.'
+                    );
+
+                    var arrivalDate = parseISODate(payload.arrival);
+                    var departureDate = parseISODate(payload.departure);
+                    var nextRange = findNextAvailableRange(state.blockedRanges, arrivalDate, departureDate);
+                    var suggestionRange = null;
+                    var suggestionText = '';
+
+                    if (nextRange && nextRange.start && nextRange.end) {
+                        suggestionRange = {
+                            start: toISODate(nextRange.start),
+                            end: toISODate(nextRange.end)
+                        };
+                        suggestionText = formatSuggestionRange(state, suggestionRange);
+                    } else {
+                        suggestionText = getText(
+                            listingData,
+                            'availabilityNoSuggestion',
+                            "We'll follow up shortly with the next available dates."
+                        );
+                    }
+
+                    setAvailabilityState(state, 'unavailable', unavailableMessage, suggestionText, suggestionRange);
+
+                    var combinedMessage = suggestionText ? unavailableMessage + ' ' + suggestionText : unavailableMessage;
+                    writeMessage(state, 'error', combinedMessage.trim());
+                    setButtonDisabled(state.continueButton, true);
+                    return;
+                }
+
+                setAvailabilityState(state, 'error', (error && error.message) || fallback, '', null);
                 writeMessage(state, 'error', (error && error.message) || fallback);
                 setButtonDisabled(state.continueButton, true);
             })
@@ -844,7 +1085,9 @@
         var continueButton = continueButtons.length ? continueButtons[0] : null;
         var message = widget.querySelector(SELECTORS.message);
         var availability = widget.querySelector(SELECTORS.availability);
-        var calendar = widget.querySelector(SELECTORS.calendar);
+        var availabilityStatus = availability ? availability.querySelector('[data-availability="status"]') : null;
+        var availabilitySuggestion = availability ? availability.querySelector('[data-availability="suggestion"]') : null;
+        var availabilityApply = availability ? availability.querySelector('[data-availability="apply"]') : null;
 
         if (continueButtons.length > 1) {
             for (var i = 1; i < continueButtons.length; i += 1) {
@@ -886,7 +1129,9 @@
             continueButton: continueButton,
             message: message,
             availability: availability,
-            calendar: calendar,
+            availabilityStatus: availabilityStatus,
+            availabilitySuggestion: availabilitySuggestion,
+            availabilityApply: availabilityApply,
             baseRate: baseRate,
             formatCurrency: createFormatter(currency),
             summaryTargets: collectSummaryTargets(widget),
@@ -897,8 +1142,34 @@
             latestQuote: null,
             lastBreakdown: null,
             quoteTimer: null,
-            quoteAbort: null
+            quoteAbort: null,
+            availabilityStatusType: '',
+            blockedRanges: [],
+            availabilityData: null,
+            suggestedRange: null
         };
+
+        if (availabilityApply) {
+            availabilityApply.addEventListener('click', function () {
+                if (!state.suggestedRange) {
+                    return;
+                }
+
+                if (state.form && state.form.arrival) {
+                    state.form.arrival.value = state.suggestedRange.start;
+                }
+
+                if (state.form && state.form.departure) {
+                    state.form.departure.value = state.suggestedRange.end;
+                }
+
+                var inputEvent = new window.Event('input', { bubbles: true });
+                var changeEvent = new window.Event('change', { bubbles: true });
+
+                state.form.dispatchEvent(inputEvent);
+                state.form.dispatchEvent(changeEvent);
+            });
+        }
 
         form.addEventListener('submit', function (event) {
             event.preventDefault();
@@ -922,6 +1193,13 @@
                     state,
                     'info',
                     getText(state.listingData, 'quotePrompt', 'Select arrival and departure dates to see pricing.')
+                );
+                setAvailabilityState(
+                    state,
+                    'idle',
+                    getText(state.listingData, 'availabilityPrompt', 'Start by selecting your check-in and checkout dates.'),
+                    '',
+                    null
                 );
                 return;
             }
@@ -960,6 +1238,13 @@
             resetPricing(state);
             setButtonDisabled(state.continueButton, true);
             writeMessage(state, 'info', getText(state.listingData, 'quoteLoading', 'Calculating pricing…'));
+            setAvailabilityState(
+                state,
+                'checking',
+                getText(state.listingData, 'availabilityChecking', 'Checking availability…'),
+                '',
+                null
+            );
             scheduleQuote(state);
         };
 
@@ -985,6 +1270,13 @@
 
         updateSummary(state, readForm(form));
         resetPricing(state);
+        setAvailabilityState(
+            state,
+            'idle',
+            getText(state.listingData, 'availabilityPrompt', 'Start by selecting your check-in and checkout dates.'),
+            '',
+            null
+        );
         fetchAvailability(state);
         requestQuote(state);
     }

--- a/templates/listing/listing.php
+++ b/templates/listing/listing.php
@@ -35,125 +35,132 @@ $excerpt = get_the_excerpt( $rental );
     <?php endif; ?>
 
     <div class="vrsp-booking-widget" data-vrsp-widget>
-        <section class="vrsp-card vrsp-card--availability">
+        <section class="vrsp-card vrsp-card--dates">
             <header class="vrsp-card__header">
                 <h2><?php esc_html_e( 'Check Availability', 'vr-single-property' ); ?></h2>
+                <p><?php esc_html_e( "Start by selecting your check-in and checkout dates. We'll confirm availability and suggest the next open stay if your first choice is booked.", 'vr-single-property' ); ?></p>
             </header>
             <div class="vrsp-availability" data-vrsp="availability" data-base-rate="<?php echo esc_attr( number_format_i18n( $base_rate, 2 ) ); ?>" data-currency="<?php echo esc_attr( $currency ); ?>">
-            <div class="vrsp-availability__calendar" data-vrsp="calendar" aria-live="polite"></div>
-            <div class="vrsp-availability__details">
-                <div class="vrsp-availability__dates">
-                    <h3><?php esc_html_e( 'Your stay', 'vr-single-property' ); ?></h3>
-                    <dl>
-                        <div>
-                            <dt><?php esc_html_e( 'Check-in', 'vr-single-property' ); ?></dt>
-                            <dd data-summary="arrival">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Check-out', 'vr-single-property' ); ?></dt>
-                            <dd data-summary="departure">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Nights', 'vr-single-property' ); ?></dt>
-                            <dd data-summary="nights">—</dd>
-                        </div>
-                    </dl>
-                </div>
-                <div class="vrsp-availability__pricing" data-vrsp="pricing">
-                    <h3><?php esc_html_e( 'Trip pricing', 'vr-single-property' ); ?></h3>
-                    <dl>
-                        <div>
-                            <dt><?php esc_html_e( 'Stay subtotal', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="stay">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Cleaning fee', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="cleaning">—</dd>
-                        </div>
-                        <div style="display:none;" data-pricing-row="discount">
-                            <dt><?php esc_html_e( 'Coupon discount', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="discount">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Taxes &amp; fees', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="taxes">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Total', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="total">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Due today', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="deposit">—</dd>
-                        </div>
-                        <div>
-                            <dt><?php esc_html_e( 'Balance due', 'vr-single-property' ); ?></dt>
-                            <dd data-pricing="balance">—</dd>
-                        </div>
-                    </dl>
-                    <p class="vrsp-availability__note" data-pricing="note"></p>
-                </div>
+                <div class="vrsp-availability__status" data-availability="status" aria-live="polite"></div>
+                <div class="vrsp-availability__suggestion" data-availability="suggestion" aria-live="polite"></div>
+                <button type="button" class="vrsp-availability__apply" data-availability="apply" hidden>
+                    <?php esc_html_e( 'Use these dates', 'vr-single-property' ); ?>
+                </button>
             </div>
-        </div>
-    </section>
+        </section>
 
-    <section class="vrsp-card vrsp-card--form">
-        <header class="vrsp-card__header">
-            <h2><?php esc_html_e( 'Reserve Your Stay', 'vr-single-property' ); ?></h2>
-            <p><?php esc_html_e( 'Enter your stay details to see live pricing. When it looks good, continue to secure payment.', 'vr-single-property' ); ?></p>
-        </header>
-        <form class="vrsp-form" data-vrsp="form">
-            <div class="vrsp-form__grid">
-                <label>
-                    <span><?php esc_html_e( 'Arrival', 'vr-single-property' ); ?></span>
-                    <input type="date" name="arrival" required />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Departure', 'vr-single-property' ); ?></span>
-                    <input type="date" name="departure" required />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Guests', 'vr-single-property' ); ?></span>
-                    <input type="number" name="guests" min="1" value="2" />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Coupon Code', 'vr-single-property' ); ?></span>
-                    <input type="text" name="coupon" />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'First Name', 'vr-single-property' ); ?></span>
-                    <input type="text" name="first_name" required />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Last Name', 'vr-single-property' ); ?></span>
-                    <input type="text" name="last_name" required />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Email', 'vr-single-property' ); ?></span>
-                    <input type="email" name="email" required />
-                </label>
-                <label>
-                    <span><?php esc_html_e( 'Mobile Number', 'vr-single-property' ); ?></span>
-                    <input type="tel" name="phone" />
-                </label>
+        <section class="vrsp-card vrsp-card--form">
+            <header class="vrsp-card__header">
+                <h2><?php esc_html_e( 'Reserve Your Stay', 'vr-single-property' ); ?></h2>
+                <p><?php esc_html_e( 'Enter your stay details to see live pricing. When it looks good, continue to secure payment.', 'vr-single-property' ); ?></p>
+            </header>
+            <form class="vrsp-form" data-vrsp="form">
+                <div class="vrsp-form__grid">
+                    <label>
+                        <span><?php esc_html_e( 'Arrival', 'vr-single-property' ); ?></span>
+                        <input type="date" name="arrival" required />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Departure', 'vr-single-property' ); ?></span>
+                        <input type="date" name="departure" required />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Guests', 'vr-single-property' ); ?></span>
+                        <input type="number" name="guests" min="1" value="2" />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Coupon Code', 'vr-single-property' ); ?></span>
+                        <input type="text" name="coupon" />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'First Name', 'vr-single-property' ); ?></span>
+                        <input type="text" name="first_name" required />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Last Name', 'vr-single-property' ); ?></span>
+                        <input type="text" name="last_name" required />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Email', 'vr-single-property' ); ?></span>
+                        <input type="email" name="email" required />
+                    </label>
+                    <label>
+                        <span><?php esc_html_e( 'Mobile Number', 'vr-single-property' ); ?></span>
+                        <input type="tel" name="phone" />
+                    </label>
+                </div>
+                <fieldset class="vrsp-form__payment" data-vrsp="payment">
+                    <legend><?php esc_html_e( 'Payment preference', 'vr-single-property' ); ?></legend>
+                    <label>
+                        <input type="radio" name="payment_option" value="deposit" data-payment="deposit" checked />
+                        <?php esc_html_e( 'Pay 50% deposit today', 'vr-single-property' ); ?>
+                    </label>
+                    <label>
+                        <input type="radio" name="payment_option" value="full" data-payment="full" />
+                        <?php esc_html_e( 'Pay in full today', 'vr-single-property' ); ?>
+                    </label>
+                    <p class="vrsp-form__payment-note" data-payment="note"></p>
+                </fieldset>
+                <div class="vrsp-form__actions">
+                    <button type="button" class="vrsp-form__continue" data-vrsp="continue" disabled><?php esc_html_e( 'Continue to Secure Payment', 'vr-single-property' ); ?></button>
+                </div>
+            </form>
+            <div class="vrsp-form__summary">
+                <div class="vrsp-availability__details">
+                    <div class="vrsp-availability__dates">
+                        <h3><?php esc_html_e( 'Your stay', 'vr-single-property' ); ?></h3>
+                        <dl>
+                            <div>
+                                <dt><?php esc_html_e( 'Check-in', 'vr-single-property' ); ?></dt>
+                                <dd data-summary="arrival">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Check-out', 'vr-single-property' ); ?></dt>
+                                <dd data-summary="departure">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Nights', 'vr-single-property' ); ?></dt>
+                                <dd data-summary="nights">—</dd>
+                            </div>
+                        </dl>
+                    </div>
+                    <div class="vrsp-availability__pricing" data-vrsp="pricing">
+                        <h3><?php esc_html_e( 'Trip pricing', 'vr-single-property' ); ?></h3>
+                        <dl>
+                            <div>
+                                <dt><?php esc_html_e( 'Stay subtotal', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="stay">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Cleaning fee', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="cleaning">—</dd>
+                            </div>
+                            <div style="display:none;" data-pricing-row="discount">
+                                <dt><?php esc_html_e( 'Coupon discount', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="discount">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Taxes &amp; fees', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="taxes">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Total', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="total">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Due today', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="deposit">—</dd>
+                            </div>
+                            <div>
+                                <dt><?php esc_html_e( 'Balance due', 'vr-single-property' ); ?></dt>
+                                <dd data-pricing="balance">—</dd>
+                            </div>
+                        </dl>
+                        <p class="vrsp-availability__note" data-pricing="note"></p>
+                    </div>
+                </div>
             </div>
-            <fieldset class="vrsp-form__payment" data-vrsp="payment">
-                <legend><?php esc_html_e( 'Payment preference', 'vr-single-property' ); ?></legend>
-                <label>
-                    <input type="radio" name="payment_option" value="deposit" data-payment="deposit" checked />
-                    <?php esc_html_e( 'Pay 50% deposit today', 'vr-single-property' ); ?>
-                </label>
-                <label>
-                    <input type="radio" name="payment_option" value="full" data-payment="full" />
-                    <?php esc_html_e( 'Pay in full today', 'vr-single-property' ); ?>
-                </label>
-                <p class="vrsp-form__payment-note" data-payment="note"></p>
-            </fieldset>
-            <div class="vrsp-form__actions">
-                <button type="button" class="vrsp-form__continue" data-vrsp="continue" disabled><?php esc_html_e( 'Continue to Secure Payment', 'vr-single-property' ); ?></button>
-            </div>
-        </form>
-        <div class="vrsp-message" data-vrsp="message" aria-live="polite"></div>
+            <div class="vrsp-message" data-vrsp="message" aria-live="polite"></div>
         </section>
     </div>
 </article>


### PR DESCRIPTION
## Summary
- replace the calendar-style availability card with a date-first prompt and move the stay and pricing summary beside the form
- enhance the booking widget logic to check availability before quoting, surface next openings when dates are blocked, and wire the "use these dates" shortcut
- style the refreshed availability status UI and expose new localized strings for the updated messaging

## Testing
- php -l templates/listing/listing.php
- php -l includes/Blocks/class-listing-block.php

------
https://chatgpt.com/codex/tasks/task_e_68eb0b926d288324b6c1782d9d91b84b