### PR TITLE
Lay out reservation automation modules in responsive grid

### DIFF
--- a/admin/css/reservation-editor.css
+++ b/admin/css/reservation-editor.css
@@ -1,0 +1,31 @@
+body.post-type-vrsp_booking .vrsp-reservation-editor__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-items: stretch;
+    width: 100%;
+}
+
+body.post-type-vrsp_booking .vrsp-reservation-editor__module {
+    height: 100%;
+    min-width: 0;
+}
+
+body.post-type-vrsp_booking .vrsp-reservation-editor__module .inside {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+}
+
+body.post-type-vrsp_booking .vrsp-reservation-editor__module .inside > :last-child {
+    margin-top: auto;
+}
+
+body.post-type-vrsp_booking .vrsp-reservation-editor__grid[data-vrsp-reservation-modules] {
+    margin-top: 2rem;
+}
+
+body.post-type-vrsp_booking .vrsp-reservation-editor__grid[data-vrsp-reservation-modules] > .vrsp-reservation-editor__module {
+    box-sizing: border-box;
+}

--- a/admin/js/reservation-editor.js
+++ b/admin/js/reservation-editor.js
@@ -1,0 +1,107 @@
+(function () {
+    function normalizeText(value) {
+        return value ? value.replace(/\s+/g, ' ').trim().toLowerCase() : '';
+    }
+
+    function findHeadingByText(text) {
+        var match = normalizeText(text);
+        if (!match) {
+            return null;
+        }
+
+        var headings = document.querySelectorAll('h2, h3, h4');
+        for (var i = 0; i < headings.length; i++) {
+            if (normalizeText(headings[i].textContent) === match) {
+                return headings[i];
+            }
+        }
+
+        return null;
+    }
+
+    function findModuleRoot(element) {
+        if (!element) {
+            return null;
+        }
+
+        var selectors = [
+            '[data-vrsp-card]',
+            '.vrsp-card',
+            '.vrsp-module',
+            '.automation-card',
+            '.automation-module',
+            '.journey-module',
+            '.card',
+            'section',
+            'article',
+            '.postbox'
+        ];
+
+        for (var i = 0; i < selectors.length; i++) {
+            var root = element.closest(selectors[i]);
+            if (root) {
+                return root;
+            }
+        }
+
+        return element.parentElement;
+    }
+
+    function moveModules() {
+        if (!document.body.classList.contains('post-type-vrsp_booking')) {
+            return;
+        }
+
+        var moduleNames = [
+            'Guest Portal Invitation',
+            'Guest Directory',
+            'Communications Feed',
+            'Guest Portal Promotions',
+            'Access Code Delivery',
+            'Welcome Touchpoint',
+            'Platform Reservation',
+            'Reservation details'
+        ];
+
+        var grid;
+        var gridParent;
+
+        moduleNames.forEach(function (name) {
+            var heading = findHeadingByText(name);
+            if (!heading) {
+                return;
+            }
+
+            var root = findModuleRoot(heading);
+            if (!root || root.dataset.vrspReservationProcessed === '1') {
+                return;
+            }
+
+            if (!grid) {
+                gridParent = root.parentElement;
+                if (!gridParent) {
+                    return;
+                }
+
+                grid = document.createElement('div');
+                grid.className = 'vrsp-reservation-editor__grid';
+                grid.setAttribute('data-vrsp-reservation-modules', 'true');
+                gridParent.insertBefore(grid, root);
+            }
+
+            root.dataset.vrspReservationProcessed = '1';
+            root.classList.add('vrsp-reservation-editor__module');
+            grid.appendChild(root);
+        });
+
+        if (!grid || !grid.children.length) {
+            return;
+        }
+    }
+
+    if ('loading' === document.readyState) {
+        document.addEventListener('DOMContentLoaded', moveModules);
+    } else {
+        moveModules();
+    }
+})();

--- a/includes/Admin/class-menu.php
+++ b/includes/Admin/class-menu.php
@@ -82,13 +82,21 @@ $this->settings->prime_cache( $sanitized );
 return $sanitized;
 }
 
-public function enqueue_assets( string $hook ): void {
-if ( false === strpos( $hook, 'vrsp' ) ) {
-return;
-}
+    public function enqueue_assets( string $hook ): void {
+        $screen            = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+        $is_booking_editor = $screen && 'vrsp_booking' === $screen->post_type && in_array( $hook, [ 'post.php', 'post-new.php' ], true );
 
-wp_enqueue_style( 'vrsp-admin', VRSP_PLUGIN_URL . 'admin/css/admin.css', [], VRSP_VERSION );
-}
+        if ( false === strpos( $hook, 'vrsp' ) && ! $is_booking_editor ) {
+            return;
+        }
+
+        wp_enqueue_style( 'vrsp-admin', VRSP_PLUGIN_URL . 'admin/css/admin.css', [], VRSP_VERSION );
+
+        if ( $is_booking_editor ) {
+            wp_enqueue_style( 'vrsp-reservation-editor', VRSP_PLUGIN_URL . 'admin/css/reservation-editor.css', [], VRSP_VERSION );
+            wp_enqueue_script( 'vrsp-reservation-editor', VRSP_PLUGIN_URL . 'admin/js/reservation-editor.js', [], VRSP_VERSION, true );
+        }
+    }
 
 public function render_dashboard(): void {
 $this->render_view( 'dashboard' );


### PR DESCRIPTION
## Summary
- add a reservation editor grid stylesheet and helper script to arrange automation modules horizontally
- load reservation editor assets when editing bookings in the admin

## Testing
- php -l includes/Admin/class-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68ed5e8c2ee0832481b44aaf47638210