### PR TITLE
Normalize booking dates to WordPress timezone

### DIFF
--- a/includes/Integrations/class-ical-sync.php
+++ b/includes/Integrations/class-ical-sync.php
@@ -173,19 +173,38 @@ return implode( "\r\n", $output );
 
         $events = [];
 
-foreach ( $bookings as $booking ) {
-$arrival   = strtotime( get_post_meta( $booking->ID, '_vrsp_arrival', true ) );
-$departure = strtotime( get_post_meta( $booking->ID, '_vrsp_departure', true ) );
-if ( ! $arrival || ! $departure ) {
-continue;
-}
+        $timezone = wp_timezone();
+
+        foreach ( $bookings as $booking ) {
+            $arrival_raw   = get_post_meta( $booking->ID, '_vrsp_arrival', true );
+            $departure_raw = get_post_meta( $booking->ID, '_vrsp_departure', true );
+
+            $arrival_date = false;
+            if ( is_string( $arrival_raw ) && $arrival_raw !== '' ) {
+                $arrival_date = DateTimeImmutable::createFromFormat( '!Y-m-d', $arrival_raw, $timezone );
+                if ( $arrival_date instanceof DateTimeImmutable ) {
+                    $arrival_date = $arrival_date->setTime( 0, 0 );
+                }
+            }
+
+            $departure_date = false;
+            if ( is_string( $departure_raw ) && $departure_raw !== '' ) {
+                $departure_date = DateTimeImmutable::createFromFormat( '!Y-m-d', $departure_raw, $timezone );
+                if ( $departure_date instanceof DateTimeImmutable ) {
+                    $departure_date = $departure_date->setTime( 0, 0 );
+                }
+            }
+
+            if ( ! $arrival_date instanceof DateTimeImmutable || ! $departure_date instanceof DateTimeImmutable ) {
+                continue;
+            }
 
             $events[] = [
                 'uid'         => $booking->ID . '@' . wp_parse_url( home_url(), PHP_URL_HOST ),
                 'created'     => strtotime( $booking->post_date_gmt ),
                 'changed'     => strtotime( $booking->post_modified_gmt ),
-                'start'       => $arrival,
-                'end'         => $departure,
+                'start'       => $arrival_date->getTimestamp(),
+                'end'         => $departure_date->getTimestamp(),
                 'summary'     => get_the_title( $booking ),
                 'description' => sprintf( 'Guests: %s', get_post_meta( $booking->ID, '_vrsp_guests', true ) ),
                 'source'      => 'direct',

--- a/tests/ical-sync-test.php
+++ b/tests/ical-sync-test.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace {
     // Minimal WordPress stubs required by the tests.
-    $GLOBALS['__wp_options'] = [];
+    $GLOBALS['__wp_options']   = [];
+    $GLOBALS['__wp_posts']     = [];
+    $GLOBALS['__wp_post_meta'] = [];
+    $GLOBALS['__wp_timezone']  = 'UTC';
 
     function add_action(...$args): void {}
     function add_rewrite_rule(...$args): void {}
@@ -22,16 +25,17 @@ namespace {
         return parse_url($url, $component);
     }
     function get_posts($args = []) {
-        return [];
+        return $GLOBALS['__wp_posts'] ?? [];
     }
     function get_post_meta($post_id, $key, $single = false) {
-        return '';
+        return $GLOBALS['__wp_post_meta'][$post_id][$key] ?? '';
     }
     function get_the_title($post): string {
         return is_object($post) && isset($post->post_title) ? (string) $post->post_title : '';
     }
     function wp_timezone(): \DateTimeZone {
-        return new \DateTimeZone('UTC');
+        $timezone = $GLOBALS['__wp_timezone'] ?? 'UTC';
+        return new \DateTimeZone($timezone);
     }
     function wp_date(string $format, int $timestamp, ?\DateTimeZone $timezone = null): string {
         $date = new \DateTimeImmutable('@' . $timestamp);
@@ -130,6 +134,63 @@ ICS;
     if (count($stored) !== 2) {
         throw new RuntimeException('Imported events should be stored via update_option.');
     }
+
+    $previous_timezone = date_default_timezone_get();
+    date_default_timezone_set('Pacific/Honolulu');
+    $GLOBALS['__wp_timezone'] = 'Europe/Paris';
+
+    $booking = (object) [
+        'ID'                => 42,
+        'post_title'        => 'Channel Booking',
+        'post_date_gmt'     => '2024-08-01 10:00:00',
+        'post_modified_gmt' => '2024-08-02 12:00:00',
+    ];
+
+    update_option('vrsp_imported_ical_events', []);
+
+    $GLOBALS['__wp_posts'] = [ $booking ];
+    $GLOBALS['__wp_post_meta'][42] = [
+        '_vrsp_arrival'   => '2024-08-10',
+        '_vrsp_departure' => '2024-08-15',
+        '_vrsp_guests'    => '4',
+    ];
+
+    $sync_with_bookings = new \VRSP\Integrations\IcalSync(new \VRSP\Settings(), new \VRSP\Utilities\Logger());
+
+    $collect_reflection = new ReflectionClass($sync_with_bookings);
+    $collect_method = $collect_reflection->getMethod('collect_events');
+    $collect_method->setAccessible(true);
+    $collected_events = $collect_method->invoke($sync_with_bookings);
+
+    if (count($collected_events) !== 1) {
+        throw new RuntimeException('Expected one collected booking event.');
+    }
+
+    $expected_timezone = new DateTimeZone('Europe/Paris');
+    $expected_start = (new DateTimeImmutable('2024-08-10 00:00:00', $expected_timezone))->getTimestamp();
+    $expected_end = (new DateTimeImmutable('2024-08-15 00:00:00', $expected_timezone))->getTimestamp();
+
+    if ($collected_events[0]['start'] !== $expected_start || $collected_events[0]['end'] !== $expected_end) {
+        throw new RuntimeException('Collected booking timestamps should align with the WordPress timezone.');
+    }
+
+    $window = $sync_with_bookings->get_availability_window(
+        new DateTimeImmutable('2024-08-01 00:00:00', new DateTimeZone('UTC')),
+        new DateTimeImmutable('2024-08-31 00:00:00', new DateTimeZone('UTC'))
+    );
+
+    if (count($window) !== 1) {
+        throw new RuntimeException('Expected availability window for the collected booking.');
+    }
+
+    if ($window[0]['start'] !== '2024-08-10' || $window[0]['end'] !== '2024-08-15') {
+        throw new RuntimeException('Availability window should reflect the WordPress timezone dates.');
+    }
+
+    date_default_timezone_set($previous_timezone);
+    $GLOBALS['__wp_timezone'] = 'UTC';
+    $GLOBALS['__wp_posts'] = [];
+    $GLOBALS['__wp_post_meta'] = [];
 
     fwrite(STDOUT, "All iCal sync tests passed\n");
 }


### PR DESCRIPTION
## Summary
- parse booking arrival and departure dates in the WordPress timezone when collecting calendar events
- normalize stored timestamps to midnight local time and skip bookings with invalid dates
- extend the iCal sync test harness to cover differing server and WordPress timezones

## Testing
- php tests/ical-sync-test.php

------
https://chatgpt.com/codex/tasks/task_e_68f3dce478a88324989f6b9cace4e42e